### PR TITLE
Fix handle leak in NtQueryInformationProcess(ProcessDebugObjectHandle)

### DIFF
--- a/TitanHide/hooks.cpp
+++ b/TitanHide/hooks.cpp
@@ -271,6 +271,17 @@ static NTSTATUS NTAPI HookNtQueryInformationProcess(
                 {
                     BACKUP_RETURNLENGTH();
 
+                    __try
+                    {
+                        // This was a successful request and a valid handle was returned.
+                        // That means we should close it before we nuke it to prevent handle leaks.
+                        ObCloseHandle(*(PHANDLE)ProcessInformation, KernelMode);
+                    }
+                    __except(EXCEPTION_EXECUTE_HANDLER)
+                    {
+                        NOTHING;
+                    }
+
                     *(ULONG_PTR*)ProcessInformation = 0;
 
                     RESTORE_RETURNLENGTH();


### PR DESCRIPTION
See #29. (1)

The only thing I have to say for myself is that `git blame` did not point at me.