### PR TITLE
Use randomised pool tags

### DIFF
--- a/TitanHide/_global.h
+++ b/TitanHide/_global.h
@@ -10,7 +10,7 @@ extern "C"
 {
 #endif
 
-#include <ntddk.h>
+#include <ntifs.h>
 #include <ntddstor.h>
 #include <mountdev.h>
 #include <ntddvol.h>
@@ -21,6 +21,7 @@ extern "C"
 }
 #endif
 
+ULONG GetPoolTag();
 void* RtlAllocateMemory(bool InZeroMemory, SIZE_T InSize);
 void RtlFreeMemory(void* InPointer);
 NTSTATUS RtlSuperCopyMemory(IN VOID UNALIGNED* Destination, IN CONST VOID UNALIGNED* Source, IN ULONG Length);

--- a/TitanHide/undocumented.cpp
+++ b/TitanHide/undocumented.cpp
@@ -409,7 +409,7 @@ PVOID Undocumented::GetKernelBase(PULONG pImageSize)
         return NULL;
     }
 
-    pSystemInfoBuffer = (PSYSTEM_MODULE_INFORMATION)ExAllocatePoolWithTag(NonPagedPool, SystemInfoBufferSize * 2, 'HIDE');
+    pSystemInfoBuffer = (PSYSTEM_MODULE_INFORMATION)ExAllocatePoolWithTag(NonPagedPool, SystemInfoBufferSize * 2, GetPoolTag());
 
     if(!pSystemInfoBuffer)
     {

--- a/TitanHide/undocumented.h
+++ b/TitanHide/undocumented.h
@@ -18,11 +18,9 @@ typedef struct _OBJECT_ALL_INFORMATION
 } OBJECT_ALL_INFORMATION, *POBJECT_ALL_INFORMATION;
 
 //enums
-typedef enum _OBJECT_INFORMATION_CLASS
-{
-    ObjectTypeInformation = 2,
-    ObjectTypesInformation = 3
-} OBJECT_INFORMATION_CLASS, *POBJECT_INFORMATION_CLASS;
+
+// OBJECT_INFORMATION_CLASS
+#define ObjectTypesInformation 3
 
 typedef enum _SYSTEM_INFORMATION_CLASS
 {


### PR DESCRIPTION
Currently the driver uses the hardcoded pool tag `'HIDE'` for all allocations, which is a potential detection vector. This makes allocations use a random 'popular' pool tag (pulled from WinDbg's `pooltag.txt`) instead.