### PR TITLE
replace some Nt* APIs with Zw* version

### DIFF
--- a/TitanHide/undocumented.h
+++ b/TitanHide/undocumented.h
@@ -499,6 +499,12 @@ public:
     static NTSTATUS NTAPI KeRaiseUserException(
         IN NTSTATUS ExceptionCode);
 
+    static NTSTATUS NTAPI ZwSetInformationThread(
+        IN HANDLE ThreadHandle,
+        IN THREADINFOCLASS ThreadInformationClass,
+        IN PVOID ThreadInformation,
+        IN ULONG ThreadInformationLength);
+
     static NTSTATUS NTAPI NtSetInformationThread(
         IN HANDLE ThreadHandle,
         IN THREADINFOCLASS ThreadInformationClass,
@@ -526,9 +532,26 @@ public:
         IN ULONG OutputBufferLength,
         OUT PULONG ReturnLength OPTIONAL);
 
+    static NTSTATUS NTAPI ZwTerminateThread(
+        IN HANDLE ThreadHandle OPTIONAL,
+        IN NTSTATUS ExitStatus);
+
     static NTSTATUS NTAPI NtTerminateThread(
         IN HANDLE ThreadHandle OPTIONAL,
         IN NTSTATUS ExitStatus);
+
+    static NTSTATUS NTAPI ZwCreateThreadEx(
+        OUT PHANDLE ThreadHandle,
+        IN ACCESS_MASK DesiredAccess,
+        IN POBJECT_ATTRIBUTES ObjectAttributes OPTIONAL,
+        IN HANDLE ProcessHandle,
+        IN PUSER_THREAD_START_ROUTINE StartRoutine,
+        IN PVOID Argument OPTIONAL,
+        IN ULONG CreateFlags,
+        IN SIZE_T ZeroBits OPTIONAL,
+        IN SIZE_T StackSize OPTIONAL,
+        IN SIZE_T MaximumStackSize OPTIONAL,
+        IN PPS_ATTRIBUTE_LIST AttributeList OPTIONAL);
 
     static NTSTATUS NTAPI NtCreateThreadEx(
         OUT PHANDLE ThreadHandle,


### PR DESCRIPTION
Hi, I noticed there is a failure log line in `TitanHide.log` when I started debugging a non-administrator process:
```log
[TITANHIDE] Failed to undo HideThreadHideFromDebugger in running threads! Status = 0xC0000005
[TITANHIDE] HiderProcessData OK!
```

After some investigation, I found the bad NTSTATUS code was came from line 213, TitanHide/threadhidefromdbg.cpp:
https://github.com/mrexodia/TitanHide/blob/6a5a68a2447ad9454adfcbd9390ec05b9dcef2d6/TitanHide/threadhidefromdbg.cpp#L212-L215

The argument `&Size` is a pointer to the variable on kernel stack. However, NtQuerySystemInformation sees `PreviousMode` is UserMode, because `PreviousMode` is set and remains unchanged since IRP_MJ_WRITE handling begins. An STATUS_ACCESS_VIOLATION is returned, bacause NtQuerySystemInformation sees a user-mode program is requesting to write something to kernel address space.

To fix it, `Undocumented::NtQuerySystemInformation` should be replaced with `Undocumented::ZwQuerySystemInformation`. Moreover, according to [microsoft's guide](https://learn.microsoft.com/en-us/windows-hardware/drivers/kernel/using-nt-and-zw-versions-of-the-native-system-services-routines), all Nt* API calls in `threadhidefromdbg.cpp` shoud be replaced with Zw* version.