### PR TITLE
fix kernel arbitrary write zero vulnerability

### DIFF
--- a/TitanHide/hooks.cpp
+++ b/TitanHide/hooks.cpp
@@ -480,6 +480,8 @@ static NTSTATUS NTAPI HookNtQueryInformationProcess(
 
         __try
         {
+            ProbeForWrite(ProcessInformation, sizeof(HANDLE), 1);
+
             if (ReturnLength != nullptr)
                 ProbeForWrite(ReturnLength, sizeof(ULONG), 1);
 


### PR DESCRIPTION
In `HookNtQueryInformationProcess`, Titanhide does not validate if `ProcessInformation` is a user space address. Any process for which TitanHide hides debugging can pass a writable kernel address, e.g. the address to `nt!KeServiceDescriptorTable`, and cause system BSOD. This is a small fix to the vulnerability.