### PR TITLE
Update ExAllocatePoolWithTag

### DIFF
--- a/TitanHide/_global.cpp
+++ b/TitanHide/_global.cpp
@@ -48,11 +48,9 @@ ULONG GetPoolTag()
     return PoolTags[Index];
 }
 
-void* RtlAllocateMemory(bool InZeroMemory, SIZE_T InSize)
+void* RtlAllocateMemory(SIZE_T InSize)
 {
     void* Result = ExAllocatePoolZero(NonPagedPool, InSize, GetPoolTag());
-    if(InZeroMemory && (Result != NULL))
-        RtlZeroMemory(Result, InSize);
     return Result;
 }
 

--- a/TitanHide/_global.cpp
+++ b/TitanHide/_global.cpp
@@ -50,7 +50,7 @@ ULONG GetPoolTag()
 
 void* RtlAllocateMemory(bool InZeroMemory, SIZE_T InSize)
 {
-    void* Result = ExAllocatePoolWithTag(NonPagedPool, InSize, GetPoolTag());
+    void* Result = ExAllocatePoolZero(NonPagedPool, InSize, GetPoolTag());
     if(InZeroMemory && (Result != NULL))
         RtlZeroMemory(Result, InSize);
     return Result;

--- a/TitanHide/_global.h
+++ b/TitanHide/_global.h
@@ -22,7 +22,7 @@ extern "C"
 #endif
 
 ULONG GetPoolTag();
-void* RtlAllocateMemory(bool InZeroMemory, SIZE_T InSize);
+void* RtlAllocateMemory(SIZE_T InSize);
 void RtlFreeMemory(void* InPointer);
 NTSTATUS RtlSuperCopyMemory(IN VOID UNALIGNED* Destination, IN CONST VOID UNALIGNED* Source, IN ULONG Length);
 

--- a/TitanHide/hooklib.cpp
+++ b/TitanHide/hooklib.cpp
@@ -4,7 +4,7 @@
 static HOOK hook_internal(ULONG_PTR addr, void* newfunc)
 {
     //allocate structure
-    HOOK hook = (HOOK)RtlAllocateMemory(true, sizeof(HOOKSTRUCT));
+    HOOK hook = (HOOK)RtlAllocateMemory(sizeof(HOOKSTRUCT));
     //set hooking address
     hook->addr = addr;
     //set hooking opcode

--- a/TitanHide/ntdll.cpp
+++ b/TitanHide/ntdll.cpp
@@ -41,7 +41,7 @@ NTSTATUS NTDLL::Initialize()
         {
             FileSize = StandardInformation.EndOfFile.LowPart;
             Log("[TITANHIDE] FileSize of ntdll.dll is %08X!\r\n", StandardInformation.EndOfFile.LowPart);
-            FileData = (unsigned char*)RtlAllocateMemory(true, FileSize);
+            FileData = (unsigned char*)RtlAllocateMemory(FileSize);
 
             LARGE_INTEGER ByteOffset;
             ByteOffset.LowPart = ByteOffset.HighPart = 0;

--- a/TitanHide/threadhidefromdbg.cpp
+++ b/TitanHide/threadhidefromdbg.cpp
@@ -21,7 +21,7 @@ NTSTATUS ReferenceProcessByName(_Outptr_ PEPROCESS* Process, _In_ PUNICODE_STRIN
     if(Undocumented::ZwQuerySystemInformation(SystemProcessInformation, nullptr, 0, &Size) != STATUS_INFO_LENGTH_MISMATCH)
         return STATUS_UNSUCCESSFUL;
     const PSYSTEM_PROCESS_INFORMATION SystemProcessInfo =
-        (PSYSTEM_PROCESS_INFORMATION)ExAllocatePoolWithTag(NonPagedPool, 2 * Size, 'croP');
+        (PSYSTEM_PROCESS_INFORMATION)ExAllocatePoolZero(NonPagedPool, 2 * Size, 'croP');
     if(SystemProcessInfo == nullptr)
         return STATUS_NO_MEMORY;
     NTSTATUS Status = Undocumented::ZwQuerySystemInformation(SystemProcessInformation, SystemProcessInfo, 2 * Size, nullptr);
@@ -94,7 +94,7 @@ NTSTATUS FindCrossThreadFlagsOffset(_Out_ PULONG Offset)
     }
 
     // Since the ETHREAD struct is opaque and we don't know its size, allocate for 4K possible offsets
-    const PULONG CandidateOffsets = (PULONG)ExAllocatePoolWithTag(NonPagedPool, PAGE_SIZE * sizeof(ULONG), 'drhT');
+    const PULONG CandidateOffsets = (PULONG)ExAllocatePoolZero(NonPagedPool, PAGE_SIZE * sizeof(ULONG), 'drhT');
     if(CandidateOffsets == nullptr)
         return STATUS_NO_MEMORY;
 
@@ -214,7 +214,7 @@ NTSTATUS UndoHideFromDebuggerInRunningThreads(_In_ ULONG Pid)
     if(Status != STATUS_INFO_LENGTH_MISMATCH)
         goto Exit;
 
-    SystemProcessInfo = (PSYSTEM_PROCESS_INFORMATION)ExAllocatePoolWithTag(NonPagedPool, 2 * Size, 'croP');
+    SystemProcessInfo = (PSYSTEM_PROCESS_INFORMATION)ExAllocatePoolZero(NonPagedPool, 2 * Size, 'croP');
     if(SystemProcessInfo == nullptr)
     {
         Status = STATUS_NO_MEMORY;

--- a/TitanHide/undocumented.cpp
+++ b/TitanHide/undocumented.cpp
@@ -546,7 +546,7 @@ PVOID Undocumented::GetKernelBase(PULONG pImageSize)
         return NULL;
     }
 
-    pSystemInfoBuffer = (PSYSTEM_MODULE_INFORMATION)ExAllocatePoolWithTag(NonPagedPool, SystemInfoBufferSize * 2, GetPoolTag());
+    pSystemInfoBuffer = (PSYSTEM_MODULE_INFORMATION)ExAllocatePoolZero(NonPagedPool, SystemInfoBufferSize * 2, GetPoolTag());
 
     if(!pSystemInfoBuffer)
     {

--- a/TitanHide/undocumented.cpp
+++ b/TitanHide/undocumented.cpp
@@ -554,8 +554,6 @@ PVOID Undocumented::GetKernelBase(PULONG pImageSize)
         return NULL;
     }
 
-    memset(pSystemInfoBuffer, 0, SystemInfoBufferSize * 2);
-
     status = Undocumented::ZwQuerySystemInformation(SystemModuleInformation,
              pSystemInfoBuffer,
              SystemInfoBufferSize * 2,


### PR DESCRIPTION
https://learn.microsoft.com/en-us/windows-hardware/drivers/kernel/updating-deprecated-exallocatepool-calls#driver-updates-for-versions-of-windows-earlier-than-windows-10-version-2004

Replace `ExAllocatePoolWithTag` with `ExAllocatePoolZero`. 
Now The compiler will report a warning if using  `ExAllocatePoolWithTag`.