### PR TITLE
VMProtect 3.9.1 latest Anti-Debug Patch

### DIFF
--- a/TitanHide/hooks.cpp
+++ b/TitanHide/hooks.cpp
@@ -464,6 +464,12 @@ static NTSTATUS NTAPI HookNtQueryInformationProcess(
             ProcessInformationLength == sizeof(HANDLE) &&
             Hider::IsHidden(pid, HideProcessDebugObjectHandle))
     {
+
+        NTSTATUS misaligenment_check = Undocumented::NtQueryInformationProcess(ProcessHandle, ProcessInformationClass, ProcessInformation, ProcessInformationLength, ReturnLength);
+
+        if (misaligenment_check == STATUS_DATATYPE_MISALIGNMENT)
+            return STATUS_DATATYPE_MISALIGNMENT;
+
         PEPROCESS Process;
         NTSTATUS Status = ObReferenceObjectByHandle(ProcessHandle,
                           PROCESS_QUERY_INFORMATION,


### PR DESCRIPTION
From the latest version of VMP (3.9.1), debugging verification for TitanHide has been enhanced!

It calls the NtOpenFile function to check if the **\\\\.\TitanHide** DOS name exists (this part has not been patched separately). Additionally, it performs more checks using the **NtQueryInformationProcess** function with the **ProcessDebugObjectHandle** class.

I have tried implementing part of the debugging checks performed by VMProtect.


	HANDLE hProcess = GetCurrentProcess();
	HANDLE debugObjectHandle = nullptr;
	SIZE_T Value = 1000;

	BYTE fakeBuffer[10] = { 0, };

	status = NtQueryInformationProcess(hProcess, (PROCESSINFOCLASS)ProcessDebugObjectHandle, fakeBuffer+1, sizeof(debugObjectHandle), nullptr); //<-- Since TitanHide does not filter this process, the debugger is detected!

	if (status != STATUS_DATATYPE_MISALIGNMENT)
	{
		return true;
	}

VMProtect intentionally sets the buffer address so that calling the function returns **STATUS_DATATYPE_MISALIGNMENT**. However, because TitanHide returns **STATUS_PORT_NOT_SET**, it gets detected.