### PR TITLE
Close anti-debug syscall side channels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,11 @@ jobs:
         msbuild.exe ${{ github.event.repository.name }}.sln /m /verbosity:minimal "/t:TitanHideGUI:Rebuild;TitanHideTest:Rebuild;TitanHide_x64dbg:Rebuild;TitanHide_TitanEngine:Rebuild" /p:Configuration=Release /p:Platform=x64
         msbuild.exe ${{ github.event.repository.name }}.sln /m /verbosity:minimal "/t:TitanHideGUI:Rebuild;TitanHideTest:Rebuild;TitanHide_x64dbg:Rebuild;TitanHide_OllyDbg:Rebuild;TitanHide_TitanEngine:Rebuild" /p:Configuration=Release /p:Platform=Win32
 
+    - name: Verify native ProcessDebugObjectHandle contract
+      run: |
+        .\Release\TitanHideTest.exe --process-debug-object-contract
+        .\x64\Release\TitanHideTest.exe --process-debug-object-contract
+
     - name: Install Visual Studio 2019 Build Tools
       shell: pwsh
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
         msbuild.exe ${{ github.event.repository.name }}.sln /m /verbosity:minimal "/t:TitanHideGUI:Rebuild;TitanHideTest:Rebuild;TitanHide_x64dbg:Rebuild;TitanHide_TitanEngine:Rebuild" /p:Configuration=Release /p:Platform=x64
         msbuild.exe ${{ github.event.repository.name }}.sln /m /verbosity:minimal "/t:TitanHideGUI:Rebuild;TitanHideTest:Rebuild;TitanHide_x64dbg:Rebuild;TitanHide_OllyDbg:Rebuild;TitanHide_TitanEngine:Rebuild" /p:Configuration=Release /p:Platform=Win32
 
-    - name: Verify native ProcessDebugObjectHandle contract
+    - name: Verify native anti-debug contracts
       run: |
-        .\Release\TitanHideTest.exe --process-debug-object-contract
-        .\x64\Release\TitanHideTest.exe --process-debug-object-contract
+        .\Release\TitanHideTest.exe --native-contracts
+        .\x64\Release\TitanHideTest.exe --native-contracts
 
     - name: Install Visual Studio 2019 Build Tools
       shell: pwsh

--- a/TitanHide/TitanHide.cpp
+++ b/TitanHide/TitanHide.cpp
@@ -69,6 +69,8 @@ static NTSTATUS DriverWrite(IN PDEVICE_OBJECT DeviceObject, IN PIRP Irp)
 
 extern "C" NTSTATUS DriverEntry(IN PDRIVER_OBJECT DriverObject, IN PUNICODE_STRING RegistryPath)
 {
+    Hider::Initialize();
+
     // Initialize name buffers
     RtlInitEmptyUnicodeString(&DeviceName, DeviceNameBuffer, sizeof(DeviceNameBuffer));
     RtlAppendUnicodeToString(&DeviceName, L"\\Device\\");

--- a/TitanHide/hider.cpp
+++ b/TitanHide/hider.cpp
@@ -145,7 +145,7 @@ bool Hider::ProcessData(PVOID Buffer, ULONG Size)
             }
             KeReleaseSpinLock(&HideEntriesLock, Irql);
             if((HideInfo[i].Type & (ULONG)HideThreadHideFromDebugger) != 0)
-                Hooks::RestoreVirtualThreadHides(HideInfo[i].Pid, false);
+                Hooks::ClearVirtualThreadHides(HideInfo[i].Pid, false);
         }
         break;
 
@@ -155,7 +155,7 @@ bool Hider::ProcessData(PVOID Buffer, ULONG Size)
             KeAcquireSpinLock(&HideEntriesLock, &Irql);
             EntryClear();
             KeReleaseSpinLock(&HideEntriesLock, Irql);
-            Hooks::RestoreVirtualThreadHides(0, true);
+            Hooks::ClearVirtualThreadHides(0, true);
         }
         break;
         }

--- a/TitanHide/hider.cpp
+++ b/TitanHide/hider.cpp
@@ -1,6 +1,7 @@
 #include "hider.h"
 #include "log.h"
 #include "threadhidefromdbg.h"
+#include "hooks.h"
 
 struct HIDE_ENTRY
 {
@@ -12,6 +13,7 @@ struct HIDE_ENTRY
 
 static HIDE_ENTRY HideEntries[MAX_HIDE_ENTRIES];
 static LONG TotalHideEntries = 0;
+static KSPIN_LOCK HideEntriesLock;
 
 //entry management
 static void EntryAdd(HIDE_ENTRY* NewEntry)
@@ -38,12 +40,9 @@ static void EntryDel(int EntryIndex)
             EntryClear();
             return;
         }
-        if(!EntryIndex)
-            RtlCopyMemory(&HideEntries[0], &HideEntries[1], NewTotalHideEntries * sizeof(HIDE_ENTRY));
-        else
-        {
-            RtlCopyMemory(&HideEntries[EntryIndex], &HideEntries[EntryIndex + 1], (NewTotalHideEntries - EntryIndex)*sizeof(HIDE_ENTRY));
-        }
+        // Entry order is irrelevant; replace the removed slot with the last
+        // entry so updates remain bounded while the spin lock is held.
+        HideEntries[EntryIndex] = HideEntries[NewTotalHideEntries];
         InterlockedExchange(&TotalHideEntries, NewTotalHideEntries);
     }
 }
@@ -87,6 +86,12 @@ static void EntryUnset(int EntryIndex, ULONG Type)
 }
 
 //usable functions
+void Hider::Initialize()
+{
+    KeInitializeSpinLock(&HideEntriesLock);
+    TotalHideEntries = 0;
+}
+
 bool Hider::ProcessData(PVOID Buffer, ULONG Size)
 {
     if(Size % sizeof(HIDE_INFO))
@@ -99,6 +104,8 @@ bool Hider::ProcessData(PVOID Buffer, ULONG Size)
         {
         case HidePid:
         {
+            KIRQL Irql;
+            KeAcquireSpinLock(&HideEntriesLock, &Irql);
             int FoundEntry = EntryFind(HideInfo[i].Pid);
             if(FoundEntry == -1)
             {
@@ -111,6 +118,7 @@ bool Hider::ProcessData(PVOID Buffer, ULONG Size)
             {
                 EntrySet(FoundEntry, HideInfo[i].Type);
             }
+            KeReleaseSpinLock(&HideEntriesLock, Irql);
 
             // Use DKOM to disable HideThreadHideFromDebugger in any threads in the target process that already have this flag set
             if((HideInfo[i].Type & (ULONG)HideThreadHideFromDebugger) != 0 && CrossThreadFlagsOffset != 0)
@@ -126,6 +134,8 @@ bool Hider::ProcessData(PVOID Buffer, ULONG Size)
 
         case UnhidePid:
         {
+            KIRQL Irql;
+            KeAcquireSpinLock(&HideEntriesLock, &Irql);
             int FoundEntry = EntryFind(HideInfo[i].Pid);
             if(FoundEntry != -1)
             {
@@ -133,12 +143,19 @@ bool Hider::ProcessData(PVOID Buffer, ULONG Size)
                 if(!EntryGet(FoundEntry))  //nothing left to hide for PID
                     EntryDel(FoundEntry);
             }
+            KeReleaseSpinLock(&HideEntriesLock, Irql);
+            if((HideInfo[i].Type & (ULONG)HideThreadHideFromDebugger) != 0)
+                Hooks::RestoreVirtualThreadHides(HideInfo[i].Pid, false);
         }
         break;
 
         case UnhideAll:
         {
+            KIRQL Irql;
+            KeAcquireSpinLock(&HideEntriesLock, &Irql);
             EntryClear();
+            KeReleaseSpinLock(&HideEntriesLock, Irql);
+            Hooks::RestoreVirtualThreadHides(0, true);
         }
         break;
         }
@@ -148,11 +165,15 @@ bool Hider::ProcessData(PVOID Buffer, ULONG Size)
 
 bool Hider::IsHidden(ULONG Pid, HIDE_TYPE Type)
 {
+    bool Hidden = false;
+    KIRQL Irql;
+    KeAcquireSpinLock(&HideEntriesLock, &Irql);
     int FoundEntry = EntryFind(Pid);
-    if(FoundEntry == -1)
-        return false;
-    ULONG uType = (ULONG)Type;
-    if((EntryGet(FoundEntry)&uType) == uType)
-        return true;
-    return false;
+    if(FoundEntry != -1)
+    {
+        ULONG uType = (ULONG)Type;
+        Hidden = (EntryGet(FoundEntry) & uType) == uType;
+    }
+    KeReleaseSpinLock(&HideEntriesLock, Irql);
+    return Hidden;
 }

--- a/TitanHide/hider.h
+++ b/TitanHide/hider.h
@@ -7,6 +7,7 @@
 class Hider
 {
 public:
+    static void Initialize();
     static bool ProcessData(PVOID Buffer, ULONG Size);
     static bool IsHidden(ULONG Pid, HIDE_TYPE Type);
 };

--- a/TitanHide/hooks.cpp
+++ b/TitanHide/hooks.cpp
@@ -2,6 +2,7 @@
 #include "undocumented.h"
 #include "ssdt.h"
 #include "hider.h"
+#include "threadhidefromdbg.h"
 #include "misc.h"
 #include "log.h"
 
@@ -48,24 +49,235 @@ static bool gThreadNotifyRegistered = false;
 
 #define OBJ_PROTECT_CLOSE 0x00000001L
 
+static bool RangesOverlap(
+    const void* First,
+    SIZE_T FirstSize,
+    const void* Second,
+    SIZE_T SecondSize)
+{
+    if(First == nullptr || Second == nullptr)
+        return false;
+
+    const ULONG_PTR FirstAddress = (ULONG_PTR)First;
+    const ULONG_PTR SecondAddress = (ULONG_PTR)Second;
+    if(FirstAddress <= SecondAddress)
+        return SecondAddress - FirstAddress < FirstSize;
+    return FirstAddress - SecondAddress < SecondSize;
+}
+
+struct DEBUG_OBJECT_TYPE_SIGNATURE
+{
+    ULONG InvalidAttributes;
+    GENERIC_MAPPING GenericMapping;
+    ULONG ValidAccessMask;
+    BOOLEAN SecurityRequired;
+    BOOLEAN MaintainHandleCount;
+    UCHAR TypeIndex;
+    ULONG PoolType;
+    ULONG DefaultPagedPoolCharge;
+    ULONG DefaultNonPagedPoolCharge;
+};
+
+static DEBUG_OBJECT_TYPE_SIGNATURE gDebugObjectTypeSignature = {};
+static bool gDebugObjectTypeSignatureValid = false;
+
+static bool TypeFieldMatches(
+    const void* Field,
+    const void* Expected,
+    SIZE_T Size,
+    PULONG ReturnLength)
+{
+    return RangesOverlap(Field, Size, ReturnLength, sizeof(ULONG)) ||
+           RtlCompareMemory(Field, Expected, Size) == Size;
+}
+
+static bool IsDebugObjectTypeDescriptor(
+    const OBJECT_TYPE_INFORMATION* TypeInformation,
+    PULONG ReturnLength,
+    const DEBUG_OBJECT_TYPE_SIGNATURE* Signature)
+{
+    if(!gDebugObjectTypeSignatureValid)
+        return false;
+
+    return TypeFieldMatches(&TypeInformation->InvalidAttributes,
+                            &Signature->InvalidAttributes,
+                            sizeof(Signature->InvalidAttributes),
+                            ReturnLength) &&
+           TypeFieldMatches(&TypeInformation->GenericMapping,
+                            &Signature->GenericMapping,
+                            sizeof(Signature->GenericMapping),
+                            ReturnLength) &&
+           TypeFieldMatches(&TypeInformation->ValidAccessMask,
+                            &Signature->ValidAccessMask,
+                            sizeof(Signature->ValidAccessMask),
+                            ReturnLength) &&
+           TypeFieldMatches(&TypeInformation->SecurityRequired,
+                            &Signature->SecurityRequired,
+                            sizeof(Signature->SecurityRequired),
+                            ReturnLength) &&
+           TypeFieldMatches(&TypeInformation->MaintainHandleCount,
+                            &Signature->MaintainHandleCount,
+                            sizeof(Signature->MaintainHandleCount),
+                            ReturnLength) &&
+           TypeFieldMatches(&TypeInformation->TypeIndex,
+                            &Signature->TypeIndex,
+                            sizeof(Signature->TypeIndex),
+                            ReturnLength) &&
+           TypeFieldMatches(&TypeInformation->PoolType,
+                            &Signature->PoolType,
+                            sizeof(Signature->PoolType),
+                            ReturnLength) &&
+           TypeFieldMatches(&TypeInformation->DefaultPagedPoolCharge,
+                            &Signature->DefaultPagedPoolCharge,
+                            sizeof(Signature->DefaultPagedPoolCharge),
+                            ReturnLength) &&
+           TypeFieldMatches(&TypeInformation->DefaultNonPagedPoolCharge,
+                            &Signature->DefaultNonPagedPoolCharge,
+                            sizeof(Signature->DefaultNonPagedPoolCharge),
+                            ReturnLength);
+}
+
 static bool IsDebugObjectTypeInformation(
     OBJECT_TYPE_INFORMATION* TypeInformation,
     ULONG ObjectInformationLength,
-    const UNICODE_STRING* DebugObject)
+    PULONG ReturnLength,
+    const UNICODE_STRING* DebugObject,
+    const DEBUG_OBJECT_TYPE_SIGNATURE* Signature)
 {
-    if(ObjectInformationLength < sizeof(OBJECT_TYPE_INFORMATION) + DebugObject->Length)
+    if(ObjectInformationLength < sizeof(OBJECT_TYPE_INFORMATION))
         return false;
 
     ProbeForRead(TypeInformation, sizeof(OBJECT_TYPE_INFORMATION), 1);
-    if(TypeInformation->TypeName.Length != DebugObject->Length)
+    if(IsDebugObjectTypeDescriptor(TypeInformation, ReturnLength, Signature))
+        return true;
+
+    if(ObjectInformationLength < sizeof(OBJECT_TYPE_INFORMATION) + DebugObject->Length ||
+            TypeInformation->TypeName.Length != DebugObject->Length)
+    {
         return false;
+    }
 
     // NtQueryObject stores the type name directly after the fixed-size structure.
     // Do not use TypeName.Buffer here: ReturnLength is written last by the kernel
     // and callers may deliberately overlap it with that pointer.
     WCHAR* InlineTypeName = (WCHAR*)(TypeInformation + 1);
+    if(RangesOverlap(InlineTypeName, DebugObject->Length, ReturnLength, sizeof(ULONG)))
+        return false;
     ProbeForRead(InlineTypeName, DebugObject->Length, 1);
     return RtlCompareMemory(InlineTypeName, DebugObject->Buffer, DebugObject->Length) == DebugObject->Length;
+}
+
+static void InitializeDebugObjectTypeSignature()
+{
+    gDebugObjectTypeSignatureValid = false;
+    RtlZeroMemory(&gDebugObjectTypeSignature,
+                  sizeof(gDebugObjectTypeSignature));
+
+    ULONG BufferSize = 0;
+    NTSTATUS Status = ZwQueryObject(
+                          nullptr,
+                          (OBJECT_INFORMATION_CLASS)ObjectTypesInformation,
+                          nullptr,
+                          0,
+                          &BufferSize);
+    if(Status != STATUS_INFO_LENGTH_MISMATCH || BufferSize == 0)
+        return;
+
+    constexpr ULONG MaximumBufferSize = 1024 * 1024;
+    for(ULONG Attempt = 0; Attempt < 4; Attempt++)
+    {
+        if(BufferSize > MaximumBufferSize || BufferSize > MAXULONG - PAGE_SIZE)
+            return;
+        BufferSize += PAGE_SIZE;
+
+        OBJECT_ALL_INFORMATION* AllInformation =
+            (OBJECT_ALL_INFORMATION*)ExAllocatePoolWithTag(
+                PagedPool,
+                BufferSize,
+                'tObT');
+        if(AllInformation == nullptr)
+            return;
+
+        ULONG RequiredSize = 0;
+        Status = ZwQueryObject(
+                     nullptr,
+                     (OBJECT_INFORMATION_CLASS)ObjectTypesInformation,
+                     AllInformation,
+                     BufferSize,
+                     &RequiredSize);
+        if(Status == STATUS_INFO_LENGTH_MISMATCH)
+        {
+            ExFreePoolWithTag(AllInformation, 'tObT');
+            BufferSize = RequiredSize > BufferSize ? RequiredSize : BufferSize;
+            continue;
+        }
+        if(!NT_SUCCESS(Status))
+        {
+            ExFreePoolWithTag(AllInformation, 'tObT');
+            return;
+        }
+
+        const UNICODE_STRING DebugObject = RTL_CONSTANT_STRING(L"DebugObject");
+        unsigned char* BufferStart = (unsigned char*)AllInformation;
+        unsigned char* BufferEnd = BufferStart + BufferSize;
+        unsigned char* Location =
+            (unsigned char*)AllInformation->ObjectTypeInformation;
+        for(ULONG i = 0; i < AllInformation->NumberOfObjects; i++)
+        {
+            if(Location > BufferEnd ||
+                    (SIZE_T)(BufferEnd - Location) < sizeof(OBJECT_TYPE_INFORMATION))
+            {
+                break;
+            }
+
+            OBJECT_TYPE_INFORMATION* TypeInformation =
+                (OBJECT_TYPE_INFORMATION*)Location;
+            unsigned char* Name = (unsigned char*)TypeInformation->TypeName.Buffer;
+            if(Name < BufferStart || Name > BufferEnd ||
+                    TypeInformation->TypeName.Length > (SIZE_T)(BufferEnd - Name) ||
+                    TypeInformation->TypeName.MaximumLength >
+                        (SIZE_T)(BufferEnd - Name))
+            {
+                break;
+            }
+
+            if(RtlEqualUnicodeString(&TypeInformation->TypeName,
+                                     &DebugObject,
+                                     FALSE))
+            {
+                gDebugObjectTypeSignature.InvalidAttributes =
+                    TypeInformation->InvalidAttributes;
+                gDebugObjectTypeSignature.GenericMapping =
+                    TypeInformation->GenericMapping;
+                gDebugObjectTypeSignature.ValidAccessMask =
+                    TypeInformation->ValidAccessMask;
+                gDebugObjectTypeSignature.SecurityRequired =
+                    TypeInformation->SecurityRequired;
+                gDebugObjectTypeSignature.MaintainHandleCount =
+                    TypeInformation->MaintainHandleCount;
+                gDebugObjectTypeSignature.TypeIndex =
+                    TypeInformation->TypeIndex;
+                gDebugObjectTypeSignature.PoolType =
+                    TypeInformation->PoolType;
+                gDebugObjectTypeSignature.DefaultPagedPoolCharge =
+                    TypeInformation->DefaultPagedPoolCharge;
+                gDebugObjectTypeSignature.DefaultNonPagedPoolCharge =
+                    TypeInformation->DefaultNonPagedPoolCharge;
+                gDebugObjectTypeSignatureValid = true;
+                break;
+            }
+
+            ULONG_PTR Next = (ULONG_PTR)Name +
+                             TypeInformation->TypeName.MaximumLength;
+            Next = (Next + sizeof(void*) - 1) & -(LONG_PTR)sizeof(void*);
+            if(Next <= (ULONG_PTR)Location || Next > (ULONG_PTR)BufferEnd)
+                break;
+            Location = (unsigned char*)Next;
+        }
+
+        ExFreePoolWithTag(AllInformation, 'tObT');
+        return;
+    }
 }
 
 static void RemoveVirtualThreadHide(HANDLE ProcessId, HANDLE ThreadId)
@@ -121,7 +333,46 @@ bool Hooks::RegisterVirtualThreadHide(PETHREAD Thread)
         RemoveVirtualThreadHide(Entry.ProcessId, Entry.ThreadId);
         return false;
     }
+
+    // Unhide can race with a set request. Preserve the native state rather than
+    // leaving an untracked thread with its physical flag cleared.
+    if(Registered &&
+            !Hider::IsHidden((ULONG)(ULONG_PTR)Entry.ProcessId,
+                             HideThreadHideFromDebugger))
+    {
+        RestoreHideFromDebugger(Thread);
+        RemoveVirtualThreadHide(Entry.ProcessId, Entry.ThreadId);
+    }
     return Registered;
+}
+
+void Hooks::RestoreVirtualThreadHides(ULONG ProcessId, bool AllProcesses)
+{
+    while(true)
+    {
+        PETHREAD Thread = nullptr;
+        KIRQL Irql;
+        KeAcquireSpinLock(&gVirtualThreadHideLock, &Irql);
+        for(ULONG i = 0; i < gVirtualThreadHideEntryCount; i++)
+        {
+            if(AllProcesses ||
+                    gVirtualThreadHideEntries[i].ProcessId ==
+                        (HANDLE)(ULONG_PTR)ProcessId)
+            {
+                Thread = gVirtualThreadHideEntries[i].Thread;
+                if(!PsIsThreadTerminating(Thread))
+                    RestoreHideFromDebugger(Thread);
+                gVirtualThreadHideEntries[i] =
+                    gVirtualThreadHideEntries[--gVirtualThreadHideEntryCount];
+                break;
+            }
+        }
+        KeReleaseSpinLock(&gVirtualThreadHideLock, Irql);
+
+        if(Thread == nullptr)
+            break;
+        ObDereferenceObject(Thread);
+    }
 }
 
 static bool HasVirtualThreadHide(PETHREAD Thread)
@@ -147,6 +398,34 @@ static void ThreadNotifyRoutine(HANDLE ProcessId, HANDLE ThreadId, BOOLEAN Creat
         RemoveVirtualThreadHide(ProcessId, ThreadId);
 }
 
+static void RegisterCreatedVirtualThreadHide(PHANDLE ThreadHandle)
+{
+    __try
+    {
+        ProbeForRead(ThreadHandle, sizeof(HANDLE), 1);
+        const HANDLE CreatedThreadHandle = *ThreadHandle;
+
+        PETHREAD Thread = nullptr;
+        NTSTATUS Status = ObReferenceObjectByHandle(
+                              CreatedThreadHandle,
+                              0,
+                              *PsThreadType,
+                              ExGetPreviousMode(),
+                              (PVOID*)&Thread,
+                              nullptr);
+        if(NT_SUCCESS(Status))
+        {
+            if(!Hooks::RegisterVirtualThreadHide(Thread))
+                RestoreHideFromDebugger(Thread);
+            ObDereferenceObject(Thread);
+        }
+    }
+    __except(EXCEPTION_EXECUTE_HANDLER)
+    {
+        NOTHING;
+    }
+}
+
 static NTSTATUS NTAPI HookNtQueryInformationThread(
     IN HANDLE ThreadHandle,
     IN THREADINFOCLASS ThreadInformationClass,
@@ -154,10 +433,18 @@ static NTSTATUS NTAPI HookNtQueryInformationThread(
     IN ULONG ThreadInformationLength,
     OUT PULONG ReturnLength OPTIONAL)
 {
+    if(ExGetPreviousMode() == KernelMode)
+        return Undocumented::NtQueryInformationThread(
+                   ThreadHandle,
+                   ThreadInformationClass,
+                   ThreadInformation,
+                   ThreadInformationLength,
+                   ReturnLength);
+
     ULONG pid = (ULONG)(ULONG_PTR)PsGetCurrentProcessId();
-    ULONG targetPid = Misc::GetProcessIDFromThreadHandle(ThreadHandle);
 
 #ifdef _WIN64 // ThreadWow64Context returns STATUS_INVALID_INFO_CLASS on x86, and STATUS_INVALID_PARAMETER if PreviousMode is kernel
+    ULONG targetPid = Misc::GetProcessIDFromThreadHandle(ThreadHandle);
     if(ThreadInformationClass == ThreadWow64Context &&
             ThreadInformation != nullptr &&
             ThreadInformationLength == sizeof(WOW64_CONTEXT) &&
@@ -213,39 +500,37 @@ static NTSTATUS NTAPI HookNtQueryInformationThread(
     // Call the original function now, since querying ThreadHideFromDebugger may fail with STATUS_INVALID_INFO_CLASS (if we are on XP/2003)
     NTSTATUS Status = Undocumented::NtQueryInformationThread(ThreadHandle, ThreadInformationClass, ThreadInformation, ThreadInformationLength, ReturnLength);
 
-    if(NT_SUCCESS(Status) && ThreadInformationClass == ThreadHideFromDebugger)
+    if(NT_SUCCESS(Status) &&
+            ThreadInformationClass == ThreadHideFromDebugger &&
+            gThreadNotifyRegistered)
     {
-        if(gThreadNotifyRegistered &&
-                Hider::IsHidden(pid, HideThreadHideFromDebugger) &&
-                Hider::IsHidden(targetPid, HideThreadHideFromDebugger))
+        __try
         {
-            Log("[TITANHIDE] NtQueryInformationThread(ThreadHideFromDebugger) by %d\r\n", pid);
+            BACKUP_RETURNLENGTH();
 
-            __try
+            PETHREAD Thread = nullptr;
+            NTSTATUS ReferenceStatus = ObReferenceObjectByHandle(
+                                           ThreadHandle,
+                                           0,
+                                           *PsThreadType,
+                                           ExGetPreviousMode(),
+                                           (PVOID*)&Thread,
+                                           nullptr);
+            if(NT_SUCCESS(ReferenceStatus))
             {
-                BACKUP_RETURNLENGTH();
-
-                PETHREAD Thread = nullptr;
-                NTSTATUS ReferenceStatus = ObReferenceObjectByHandle(
-                                               ThreadHandle,
-                                               0,
-                                               *PsThreadType,
-                                               ExGetPreviousMode(),
-                                               (PVOID*)&Thread,
-                                               nullptr);
-                if(NT_SUCCESS(ReferenceStatus))
+                if(HasVirtualThreadHide(Thread))
                 {
-                    if(HasVirtualThreadHide(Thread))
-                        *(BOOLEAN*)ThreadInformation = TRUE;
-                    ObDereferenceObject(Thread);
+                    Log("[TITANHIDE] NtQueryInformationThread(ThreadHideFromDebugger) by %d\r\n", pid);
+                    *(BOOLEAN*)ThreadInformation = TRUE;
                 }
+                ObDereferenceObject(Thread);
+            }
 
-                RESTORE_RETURNLENGTH();
-            }
-            __except(EXCEPTION_EXECUTE_HANDLER)
-            {
-                Status = GetExceptionCode();
-            }
+            RESTORE_RETURNLENGTH();
+        }
+        __except(EXCEPTION_EXECUTE_HANDLER)
+        {
+            Status = GetExceptionCode();
         }
     }
 
@@ -258,12 +543,22 @@ static NTSTATUS NTAPI HookNtSetInformationThread(
     IN PVOID ThreadInformation,
     IN ULONG ThreadInformationLength)
 {
+    if(ExGetPreviousMode() == KernelMode)
+        return Undocumented::NtSetInformationThread(
+                   ThreadHandle,
+                   ThreadInformationClass,
+                   ThreadInformation,
+                   ThreadInformationLength);
+
     const ULONG pid = (ULONG)(ULONG_PTR)PsGetCurrentProcessId();
+    const ULONG targetPid = Misc::GetProcessIDFromThreadHandle(ThreadHandle);
 
     //Bug found by Aguila, thanks!
     if(ThreadInformationClass == ThreadHideFromDebugger && !ThreadInformationLength)
     {
-        if(gThreadNotifyRegistered && Hider::IsHidden(pid, HideThreadHideFromDebugger))
+        if(gThreadNotifyRegistered &&
+                Hider::IsHidden(pid, HideThreadHideFromDebugger) &&
+                Hider::IsHidden(targetPid, HideThreadHideFromDebugger))
         {
             Log("[TITANHIDE] NtSetInformationThread(ThreadHideFromDebugger) by %d\r\n", pid);
             PETHREAD Thread;
@@ -335,6 +630,8 @@ static NTSTATUS NTAPI HookNtClose(
 {
     ULONG pid = (ULONG)(ULONG_PTR)PsGetCurrentProcessId();
     KPROCESSOR_MODE PreviousMode = ExGetPreviousMode();
+    if(PreviousMode == KernelMode)
+        return ObCloseHandle(Handle, KernelMode);
     if(Hider::IsHidden(pid, HideNtClose))
     {
         KeWaitForSingleObject(&gDebugPortMutex, Executive, KernelMode, FALSE, nullptr);
@@ -399,6 +696,15 @@ static NTSTATUS NTAPI HookNtDuplicateObject(
 {
     ULONG pid = (ULONG)(ULONG_PTR)PsGetCurrentProcessId();
     KPROCESSOR_MODE PreviousMode = ExGetPreviousMode();
+    if(PreviousMode == KernelMode)
+        return Undocumented::NtDuplicateObject(
+                   SourceProcessHandle,
+                   SourceHandle,
+                   TargetProcessHandle,
+                   TargetHandle,
+                   DesiredAccess,
+                   HandleAttributes,
+                   Options);
     if(Hider::IsHidden(pid, HideNtClose))
     {
         BOOLEAN BeingDebugged = PsGetProcessDebugPort(PsGetCurrentProcess()) != nullptr;
@@ -438,6 +744,13 @@ static NTSTATUS NTAPI HookNtQuerySystemInformation(
     IN ULONG SystemInformationLength,
     OUT PULONG ReturnLength OPTIONAL)
 {
+    if(ExGetPreviousMode() == KernelMode)
+        return Undocumented::NtQuerySystemInformation(
+                   SystemInformationClass,
+                   SystemInformation,
+                   SystemInformationLength,
+                   ReturnLength);
+
     NTSTATUS ret = Undocumented::NtQuerySystemInformation(SystemInformationClass, SystemInformation, SystemInformationLength, ReturnLength);
     if(NT_SUCCESS(ret) && SystemInformation)
     {
@@ -653,13 +966,16 @@ static NTSTATUS NTAPI HookNtQueryObject(
                 BACKUP_RETURNLENGTH();
 
                 OBJECT_TYPE_INFORMATION* type = (OBJECT_TYPE_INFORMATION*)ObjectInformation;
-                if(IsDebugObjectTypeInformation(type, ObjectInformationLength, &DebugObject))
+                DEBUG_OBJECT_CONTRIBUTION Contribution;
+                if(QueryDebugObjectContribution(&Contribution) &&
+                        IsDebugObjectTypeInformation(type,
+                                                     ObjectInformationLength,
+                                                     ReturnLength,
+                                                     &DebugObject,
+                                                     &gDebugObjectTypeSignature))
                 {
                     Log("[TITANHIDE] DebugObject by %d\r\n", pid);
-
-                    DEBUG_OBJECT_CONTRIBUTION Contribution;
-                    if(QueryDebugObjectContribution(&Contribution))
-                        RemoveDebugObjectContribution(type, &Contribution);
+                    RemoveDebugObjectContribution(type, &Contribution);
                 }
 
                 RESTORE_RETURNLENGTH();
@@ -685,42 +1001,76 @@ static NTSTATUS NTAPI HookNtQueryObject(
                     return ret;
                 }
 
-                unsigned int TotalObjects = pObjectAllInfo->NumberOfObjects;
-                for(unsigned int i = 0; i < TotalObjects; i++)
+                DEBUG_OBJECT_CONTRIBUTION Contribution;
+                if(QueryDebugObjectContribution(&Contribution))
                 {
-                    if(pObjInfoLocation > BufferEnd ||
-                            (SIZE_T)(BufferEnd - pObjInfoLocation) < sizeof(OBJECT_TYPE_INFORMATION))
+                    // NumberOfObjects and any UNICODE_STRING member may have
+                    // been overwritten by ReturnLength. Walk bounded inline
+                    // names and use the live debug object's fixed type
+                    // descriptor as an independent identifier.
+                    while(pObjInfoLocation <= BufferEnd &&
+                            (SIZE_T)(BufferEnd - pObjInfoLocation) >= sizeof(OBJECT_TYPE_INFORMATION))
                     {
-                        break;
-                    }
+                        OBJECT_TYPE_INFORMATION* pObjectTypeInfo =
+                            (OBJECT_TYPE_INFORMATION*)pObjInfoLocation;
+                        ProbeForRead(pObjectTypeInfo, sizeof(OBJECT_TYPE_INFORMATION), 1);
 
-                    OBJECT_TYPE_INFORMATION* pObjectTypeInfo = (OBJECT_TYPE_INFORMATION*)pObjInfoLocation;
-                    ProbeForRead(pObjectTypeInfo, sizeof(OBJECT_TYPE_INFORMATION), 1);
-
-                    // The name is inline after the fixed structure. TypeName.Buffer
-                    // may have been overwritten by an overlapping ReturnLength.
-                    unsigned char* InlineTypeName = (unsigned char*)(pObjectTypeInfo + 1);
-                    if(InlineTypeName > BufferEnd ||
-                            pObjectTypeInfo->TypeName.MaximumLength > (SIZE_T)(BufferEnd - InlineTypeName))
-                    {
-                        break;
-                    }
-
-                    if(pObjectTypeInfo->TypeName.Length == DebugObject.Length &&
-                            pObjectTypeInfo->TypeName.Length <= pObjectTypeInfo->TypeName.MaximumLength &&
-                            RtlCompareMemory(InlineTypeName, DebugObject.Buffer, DebugObject.Length) == DebugObject.Length)
-                    {
-                        Log("[TITANHIDE] DebugObject by %d\r\n", pid);
-                        DEBUG_OBJECT_CONTRIBUTION Contribution;
-                        if(QueryDebugObjectContribution(&Contribution))
+                        unsigned char* InlineTypeName =
+                            (unsigned char*)(pObjectTypeInfo + 1);
+                        const bool DescriptorMatches =
+                            IsDebugObjectTypeDescriptor(
+                                pObjectTypeInfo,
+                                ReturnLength,
+                                &gDebugObjectTypeSignature);
+                        const bool NameMatches =
+                            (SIZE_T)(BufferEnd - InlineTypeName) >=
+                                DebugObject.Length + sizeof(WCHAR) &&
+                            !RangesOverlap(InlineTypeName,
+                                           DebugObject.Length + sizeof(WCHAR),
+                                           ReturnLength,
+                                           sizeof(ULONG)) &&
+                            RtlCompareMemory(InlineTypeName,
+                                             DebugObject.Buffer,
+                                             DebugObject.Length) == DebugObject.Length &&
+                            *(WCHAR*)(InlineTypeName + DebugObject.Length) == L'\0';
+                        if(DescriptorMatches || NameMatches)
+                        {
+                            Log("[TITANHIDE] DebugObject by %d\r\n", pid);
                             RemoveDebugObjectContribution(pObjectTypeInfo, &Contribution);
-                    }
+                            break;
+                        }
 
-                    ULONG_PTR Next = (ULONG_PTR)InlineTypeName + pObjectTypeInfo->TypeName.MaximumLength;
-                    Next = (Next + sizeof(void*) - 1) & -(LONG_PTR)sizeof(void*);
-                    if(Next <= (ULONG_PTR)pObjInfoLocation || Next > (ULONG_PTR)BufferEnd)
-                        break;
-                    pObjInfoLocation = (unsigned char*)Next;
+                        SIZE_T InlineAllocationLength = 0;
+                        if(!RangesOverlap(&pObjectTypeInfo->TypeName.MaximumLength,
+                                          sizeof(pObjectTypeInfo->TypeName.MaximumLength),
+                                          ReturnLength,
+                                          sizeof(ULONG)) &&
+                                pObjectTypeInfo->TypeName.MaximumLength >= sizeof(WCHAR) &&
+                                pObjectTypeInfo->TypeName.MaximumLength <=
+                                    (SIZE_T)(BufferEnd - InlineTypeName))
+                        {
+                            InlineAllocationLength = pObjectTypeInfo->TypeName.MaximumLength;
+                        }
+                        else
+                        {
+                            WCHAR* Character = (WCHAR*)InlineTypeName;
+                            while((SIZE_T)(BufferEnd - (unsigned char*)Character) >= sizeof(WCHAR) &&
+                                    *Character != L'\0')
+                            {
+                                Character++;
+                            }
+                            if((SIZE_T)(BufferEnd - (unsigned char*)Character) < sizeof(WCHAR))
+                                break;
+                            InlineAllocationLength =
+                                (SIZE_T)((unsigned char*)(Character + 1) - InlineTypeName);
+                        }
+
+                        ULONG_PTR Next = (ULONG_PTR)InlineTypeName + InlineAllocationLength;
+                        Next = (Next + sizeof(void*) - 1) & -(LONG_PTR)sizeof(void*);
+                        if(Next <= (ULONG_PTR)pObjInfoLocation || Next > (ULONG_PTR)BufferEnd)
+                            break;
+                        pObjInfoLocation = (unsigned char*)Next;
+                    }
                 }
 
                 RESTORE_RETURNLENGTH();
@@ -948,6 +1298,15 @@ static NTSTATUS NTAPI HookNtSystemDebugControl(
     IN ULONG OutputBufferLength,
     OUT PULONG ReturnLength)
 {
+    if(ExGetPreviousMode() == KernelMode)
+        return Undocumented::NtSystemDebugControl(
+                   Command,
+                   InputBuffer,
+                   InputBufferLength,
+                   OutputBuffer,
+                   OutputBufferLength,
+                   ReturnLength);
+
     ULONG pid = (ULONG)(ULONG_PTR)PsGetCurrentProcessId();
     if(Command != SysDbgGetTriageDump && Command != SysDbgGetLiveKernelDump &&
             Hider::IsHidden(pid, HideNtSystemDebugControl))
@@ -971,20 +1330,53 @@ static NTSTATUS NTAPI HookNtCreateThreadEx(
     IN SIZE_T MaximumStackSize OPTIONAL,
     IN PPS_ATTRIBUTE_LIST AttributeList OPTIONAL)
 {
+    if(ExGetPreviousMode() == KernelMode)
+        return Undocumented::NtCreateThreadEx(
+                   ThreadHandle,
+                   DesiredAccess,
+                   ObjectAttributes,
+                   ProcessHandle,
+                   StartRoutine,
+                   Argument,
+                   CreateFlags,
+                   ZeroBits,
+                   StackSize,
+                   MaximumStackSize,
+                   AttributeList);
+
     const ULONG pid = (ULONG)(ULONG_PTR)PsGetCurrentProcessId();
-    if(Hider::IsHidden(pid, HideThreadHideFromDebugger))
+    const ULONG targetPid = Misc::GetProcessIDFromProcessHandle(ProcessHandle);
+    const bool VirtualizeThreadHide =
+        gThreadNotifyRegistered &&
+        (CreateFlags & THREAD_CREATE_FLAGS_HIDE_FROM_DEBUGGER) != 0 &&
+        Hider::IsHidden(pid, HideThreadHideFromDebugger) &&
+        Hider::IsHidden(targetPid, HideThreadHideFromDebugger);
+    if(VirtualizeThreadHide)
     {
-        if((CreateFlags & THREAD_CREATE_FLAGS_HIDE_FROM_DEBUGGER) != 0)
-        {
-            CreateFlags &= ~THREAD_CREATE_FLAGS_HIDE_FROM_DEBUGGER;
-            Log("[TITANHIDE] NtCreateThreadEx with THREAD_CREATE_FLAGS_HIDE_FROM_DEBUGGER by %u\r\n", pid);
-        }
+        CreateFlags &= ~THREAD_CREATE_FLAGS_HIDE_FROM_DEBUGGER;
+        Log("[TITANHIDE] NtCreateThreadEx with THREAD_CREATE_FLAGS_HIDE_FROM_DEBUGGER by %u\r\n", pid);
     }
-    return Undocumented::NtCreateThreadEx(ThreadHandle, DesiredAccess, ObjectAttributes, ProcessHandle, StartRoutine, Argument, CreateFlags, ZeroBits, StackSize, MaximumStackSize, AttributeList);
+
+    NTSTATUS Status = Undocumented::NtCreateThreadEx(
+                          ThreadHandle,
+                          DesiredAccess,
+                          ObjectAttributes,
+                          ProcessHandle,
+                          StartRoutine,
+                          Argument,
+                          CreateFlags,
+                          ZeroBits,
+                          StackSize,
+                          MaximumStackSize,
+                          AttributeList);
+    if(NT_SUCCESS(Status) && VirtualizeThreadHide)
+        RegisterCreatedVirtualThreadHide(ThreadHandle);
+    return Status;
 }
 
 int Hooks::Initialize()
 {
+    InitializeDebugObjectTypeSignature();
     KeInitializeMutex(&gDebugPortMutex, 0);
     KeInitializeSpinLock(&gVirtualThreadHideLock);
     gVirtualThreadHideEntryCount = 0;
@@ -1053,9 +1445,5 @@ void Hooks::Deinitialize()
         gThreadNotifyRegistered = false;
     }
 
-    while(gVirtualThreadHideEntryCount != 0)
-    {
-        PETHREAD Thread = gVirtualThreadHideEntries[--gVirtualThreadHideEntryCount].Thread;
-        ObDereferenceObject(Thread);
-    }
+    RestoreVirtualThreadHides(0, true);
 }

--- a/TitanHide/hooks.cpp
+++ b/TitanHide/hooks.cpp
@@ -513,41 +513,105 @@ struct DEBUG_OBJECT_CONTRIBUTION
     ULONG Handles;
 };
 
+struct SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX_LOCAL
+{
+    PVOID Object;
+    ULONG_PTR UniqueProcessId;
+    ULONG_PTR HandleValue;
+    ULONG GrantedAccess;
+    USHORT CreatorBackTraceIndex;
+    USHORT ObjectTypeIndex;
+    ULONG HandleAttributes;
+    ULONG Reserved;
+};
+
+struct SYSTEM_HANDLE_INFORMATION_EX_LOCAL
+{
+    ULONG_PTR NumberOfHandles;
+    ULONG_PTR Reserved;
+    SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX_LOCAL Handles[1];
+};
+
 static bool QueryDebugObjectContribution(DEBUG_OBJECT_CONTRIBUTION* Contribution)
 {
     Contribution->Objects = 0;
     Contribution->Handles = 0;
 
-    HANDLE DebugObjectHandle = nullptr;
-    NTSTATUS Status = Undocumented::ZwQueryInformationProcess(
-                          NtCurrentProcess(),
-                          ProcessDebugObjectHandle,
-                          &DebugObjectHandle,
-                          sizeof(DebugObjectHandle),
-                          nullptr);
-    if(!NT_SUCCESS(Status) || DebugObjectHandle == nullptr)
+    // The process has one active debug-port object at most. Do not query
+    // ProcessDebugObjectHandle here: repeatedly opening that handle can retain
+    // references to the DebugObject after both debugger and debuggee exit.
+    PVOID DebugPort = PsGetProcessDebugPort(PsGetCurrentProcess());
+    if(DebugPort == nullptr)
         return false;
 
-    PUBLIC_OBJECT_BASIC_INFORMATION BasicInformation = {};
-    Status = ZwQueryObject(
-                 DebugObjectHandle,
-                 ObjectBasicInformation,
-                 &BasicInformation,
-                 sizeof(BasicInformation),
-                 nullptr);
-    ObCloseHandle(DebugObjectHandle, KernelMode);
-    if(!NT_SUCCESS(Status))
+    ULONG BufferSize = 0;
+    NTSTATUS Status = Undocumented::ZwQuerySystemInformation(
+                          SystemExtendedHandleInformation,
+                          nullptr,
+                          0,
+                          &BufferSize);
+    if(Status != STATUS_INFO_LENGTH_MISMATCH || BufferSize == 0)
         return false;
 
-    Contribution->Objects = 1;
+    constexpr ULONG MaximumBufferSize = 64 * 1024 * 1024;
+    for(ULONG Attempt = 0; Attempt < 4; Attempt++)
+    {
+        if(BufferSize > MaximumBufferSize || BufferSize > MAXULONG - PAGE_SIZE)
+            return false;
+        BufferSize += PAGE_SIZE;
 
-    // ProcessDebugObjectHandle opened the temporary handle queried above. Remove
-    // it from the per-object count to obtain the active debug object's actual
-    // contribution to the system-wide DebugObject handle total.
-    if(BasicInformation.HandleCount != 0)
-        Contribution->Handles = BasicInformation.HandleCount - 1;
+        SYSTEM_HANDLE_INFORMATION_EX_LOCAL* HandleInformation =
+            (SYSTEM_HANDLE_INFORMATION_EX_LOCAL*)ExAllocatePoolWithTag(
+                PagedPool,
+                BufferSize,
+                'hDbT');
+        if(HandleInformation == nullptr)
+            return false;
 
-    return true;
+        ULONG RequiredSize = 0;
+        Status = Undocumented::ZwQuerySystemInformation(
+                     SystemExtendedHandleInformation,
+                     HandleInformation,
+                     BufferSize,
+                     &RequiredSize);
+        if(Status == STATUS_INFO_LENGTH_MISMATCH)
+        {
+            ExFreePoolWithTag(HandleInformation, 'hDbT');
+            BufferSize = RequiredSize > BufferSize ? RequiredSize : BufferSize;
+            continue;
+        }
+        if(!NT_SUCCESS(Status))
+        {
+            ExFreePoolWithTag(HandleInformation, 'hDbT');
+            return false;
+        }
+
+        const SIZE_T HeaderSize = FIELD_OFFSET(SYSTEM_HANDLE_INFORMATION_EX_LOCAL, Handles);
+        const ULONG_PTR MaximumEntries =
+            BufferSize >= HeaderSize
+            ? (BufferSize - HeaderSize) / sizeof(SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX_LOCAL)
+            : 0;
+        if(HandleInformation->NumberOfHandles > MaximumEntries)
+        {
+            ExFreePoolWithTag(HandleInformation, 'hDbT');
+            return false;
+        }
+
+        Contribution->Objects = 1;
+        for(ULONG_PTR i = 0; i < HandleInformation->NumberOfHandles; i++)
+        {
+            if(HandleInformation->Handles[i].Object == DebugPort &&
+                    Contribution->Handles != MAXULONG)
+            {
+                Contribution->Handles++;
+            }
+        }
+
+        ExFreePoolWithTag(HandleInformation, 'hDbT');
+        return true;
+    }
+
+    return false;
 }
 
 static void RemoveDebugObjectContribution(

--- a/TitanHide/hooks.cpp
+++ b/TitanHide/hooks.cpp
@@ -552,6 +552,12 @@ static NTSTATUS NTAPI HookNtQueryInformationProcess(
             ProcessInformationLength == sizeof(HANDLE) &&
             Hider::IsHidden(pid, HideProcessDebugObjectHandle))
     {
+        // The native service checks the output alignment before validating the
+        // process handle or its access rights. Keep that ordering observable to
+        // callers using a restricted handle and a deliberately bad buffer.
+        if(((ULONG_PTR)ProcessInformation & (sizeof(ULONG) - 1)) != 0)
+            return STATUS_DATATYPE_MISALIGNMENT;
+
         PEPROCESS Process;
         NTSTATUS Status = ObReferenceObjectByHandle(ProcessHandle,
                           PROCESS_QUERY_INFORMATION,
@@ -568,7 +574,9 @@ static NTSTATUS NTAPI HookNtQueryInformationProcess(
 
         __try
         {
-            ProbeForWrite(ProcessInformation, sizeof(HANDLE), 4);
+            // Alignment was checked above; probe accessibility only after the
+            // process handle has passed PROCESS_QUERY_INFORMATION validation.
+            ProbeForWrite(ProcessInformation, sizeof(HANDLE), 1);
 
             if (ReturnLength != nullptr)
                 ProbeForWrite(ReturnLength, sizeof(ULONG), 1);

--- a/TitanHide/hooks.cpp
+++ b/TitanHide/hooks.cpp
@@ -974,7 +974,10 @@ static NTSTATUS NTAPI HookNtQueryObject(
 
                 OBJECT_ALL_INFORMATION* pObjectAllInfo = (OBJECT_ALL_INFORMATION*)ObjectInformation;
                 unsigned char* pObjInfoLocation = (unsigned char*)pObjectAllInfo->ObjectTypeInformation;
-                unsigned char* BufferEnd = (unsigned char*)ObjectInformation + ObjectInformationLength;
+                SIZE_T ReturnedLength = ObjectInformationLength;
+                if(ReturnLength != nullptr && TempReturnLength < ReturnedLength)
+                    ReturnedLength = TempReturnLength;
+                unsigned char* BufferEnd = (unsigned char*)ObjectInformation + ReturnedLength;
                 if(BufferEnd < (unsigned char*)ObjectInformation)
                 {
                     RESTORE_RETURNLENGTH();
@@ -984,12 +987,18 @@ static NTSTATUS NTAPI HookNtQueryObject(
                 DEBUG_OBJECT_CONTRIBUTION Contribution;
                 if(QueryDebugObjectContribution(&Contribution))
                 {
-                    // NumberOfObjects and any UNICODE_STRING member may have
-                    // been overwritten by ReturnLength. Walk bounded inline
-                    // names and use the live debug object's fixed type
-                    // descriptor as an independent identifier.
+                    // ReturnLength is the authoritative byte bound. Use the
+                    // native object count too unless ReturnLength overwrote it.
+                    const bool ObjectCountValid =
+                        !RangesOverlap(&pObjectAllInfo->NumberOfObjects,
+                                       sizeof(pObjectAllInfo->NumberOfObjects),
+                                       ReturnLength,
+                                       sizeof(ULONG));
+                    const ULONG TotalObjects = pObjectAllInfo->NumberOfObjects;
+                    ULONG ObjectsVisited = 0;
                     while(pObjInfoLocation <= BufferEnd &&
-                            (SIZE_T)(BufferEnd - pObjInfoLocation) >= sizeof(OBJECT_TYPE_INFORMATION))
+                            (SIZE_T)(BufferEnd - pObjInfoLocation) >= sizeof(OBJECT_TYPE_INFORMATION) &&
+                            (!ObjectCountValid || ObjectsVisited < TotalObjects))
                     {
                         OBJECT_TYPE_INFORMATION* pObjectTypeInfo =
                             (OBJECT_TYPE_INFORMATION*)pObjInfoLocation;
@@ -1050,6 +1059,7 @@ static NTSTATUS NTAPI HookNtQueryObject(
                         if(Next <= (ULONG_PTR)pObjInfoLocation || Next > (ULONG_PTR)BufferEnd)
                             break;
                         pObjInfoLocation = (unsigned char*)Next;
+                        ObjectsVisited++;
                     }
                 }
 

--- a/TitanHide/hooks.cpp
+++ b/TitanHide/hooks.cpp
@@ -18,6 +18,19 @@ static HOOK hNtSystemDebugControl = 0;
 static HOOK hNtCreateThreadEx = 0;
 static KMUTEX gDebugPortMutex;
 
+struct VIRTUAL_THREAD_HIDE_ENTRY
+{
+    HANDLE ProcessId;
+    HANDLE ThreadId;
+    PETHREAD Thread;
+};
+
+#define MAX_VIRTUAL_THREAD_HIDE_ENTRIES 4096
+static VIRTUAL_THREAD_HIDE_ENTRY gVirtualThreadHideEntries[MAX_VIRTUAL_THREAD_HIDE_ENTRIES];
+static ULONG gVirtualThreadHideEntryCount = 0;
+static KSPIN_LOCK gVirtualThreadHideLock;
+static bool gThreadNotifyRegistered = false;
+
 //https://forum.tuts4you.com/topic/40011-debugme-vmprotect-312-build-886-anti-debug-method-improved/#comment-192824
 //https://github.com/x64dbg/ScyllaHide/issues/47
 //https://github.com/mrexodia/TitanHide/issues/27
@@ -53,6 +66,85 @@ static bool IsDebugObjectTypeInformation(
     WCHAR* InlineTypeName = (WCHAR*)(TypeInformation + 1);
     ProbeForRead(InlineTypeName, DebugObject->Length, 1);
     return RtlCompareMemory(InlineTypeName, DebugObject->Buffer, DebugObject->Length) == DebugObject->Length;
+}
+
+static void RemoveVirtualThreadHide(HANDLE ProcessId, HANDLE ThreadId)
+{
+    PETHREAD Thread = nullptr;
+    KIRQL Irql;
+    KeAcquireSpinLock(&gVirtualThreadHideLock, &Irql);
+    for(ULONG i = 0; i < gVirtualThreadHideEntryCount; i++)
+    {
+        if(gVirtualThreadHideEntries[i].ProcessId == ProcessId &&
+                gVirtualThreadHideEntries[i].ThreadId == ThreadId)
+        {
+            Thread = gVirtualThreadHideEntries[i].Thread;
+            gVirtualThreadHideEntries[i] =
+                gVirtualThreadHideEntries[--gVirtualThreadHideEntryCount];
+            break;
+        }
+    }
+    KeReleaseSpinLock(&gVirtualThreadHideLock, Irql);
+    if(Thread != nullptr)
+        ObDereferenceObject(Thread);
+}
+
+static bool RegisterVirtualThreadHide(PETHREAD Thread)
+{
+    VIRTUAL_THREAD_HIDE_ENTRY Entry;
+    Entry.ProcessId = PsGetProcessId(PsGetThreadProcess(Thread));
+    Entry.ThreadId = PsGetThreadId(Thread);
+    Entry.Thread = Thread;
+
+    KIRQL Irql;
+    KeAcquireSpinLock(&gVirtualThreadHideLock, &Irql);
+    for(ULONG i = 0; i < gVirtualThreadHideEntryCount; i++)
+    {
+        if(gVirtualThreadHideEntries[i].Thread == Thread)
+        {
+            KeReleaseSpinLock(&gVirtualThreadHideLock, Irql);
+            return true;
+        }
+    }
+
+    const bool Registered = gVirtualThreadHideEntryCount < MAX_VIRTUAL_THREAD_HIDE_ENTRIES;
+    if(Registered)
+    {
+        ObReferenceObject(Thread);
+        gVirtualThreadHideEntries[gVirtualThreadHideEntryCount++] = Entry;
+    }
+    KeReleaseSpinLock(&gVirtualThreadHideLock, Irql);
+
+    // If exit notification raced ahead of registration, remove the entry now.
+    if(Registered && PsIsThreadTerminating(Thread))
+    {
+        RemoveVirtualThreadHide(Entry.ProcessId, Entry.ThreadId);
+        return false;
+    }
+    return Registered;
+}
+
+static bool HasVirtualThreadHide(PETHREAD Thread)
+{
+    bool Found = false;
+    KIRQL Irql;
+    KeAcquireSpinLock(&gVirtualThreadHideLock, &Irql);
+    for(ULONG i = 0; i < gVirtualThreadHideEntryCount; i++)
+    {
+        if(gVirtualThreadHideEntries[i].Thread == Thread)
+        {
+            Found = true;
+            break;
+        }
+    }
+    KeReleaseSpinLock(&gVirtualThreadHideLock, Irql);
+    return Found;
+}
+
+static void ThreadNotifyRoutine(HANDLE ProcessId, HANDLE ThreadId, BOOLEAN Create)
+{
+    if(!Create)
+        RemoveVirtualThreadHide(ProcessId, ThreadId);
 }
 
 static NTSTATUS NTAPI HookNtQueryInformationThread(
@@ -98,8 +190,8 @@ static NTSTATUS NTAPI HookNtQueryInformationThread(
             ProbeForWrite(&Wow64Context->ContextFlags, sizeof(ULONG), 1);
             Wow64Context->ContextFlags = OriginalContextFlags;
 
-            // If debug registers were requested, zero user input
-            if(DebugRegistersRequested)
+            // If debug registers were requested successfully, zero user input.
+            if(NT_SUCCESS(Status) && DebugRegistersRequested)
             {
                 Wow64Context->Dr0 = 0;
                 Wow64Context->Dr1 = 0;
@@ -123,7 +215,8 @@ static NTSTATUS NTAPI HookNtQueryInformationThread(
 
     if(NT_SUCCESS(Status) && ThreadInformationClass == ThreadHideFromDebugger)
     {
-        if(Hider::IsHidden(pid, HideThreadHideFromDebugger) &&
+        if(gThreadNotifyRegistered &&
+                Hider::IsHidden(pid, HideThreadHideFromDebugger) &&
                 Hider::IsHidden(targetPid, HideThreadHideFromDebugger))
         {
             Log("[TITANHIDE] NtQueryInformationThread(ThreadHideFromDebugger) by %d\r\n", pid);
@@ -132,8 +225,20 @@ static NTSTATUS NTAPI HookNtQueryInformationThread(
             {
                 BACKUP_RETURNLENGTH();
 
-                // Since they're asking, assume they're expecting "yes"
-                *(BOOLEAN*)ThreadInformation = TRUE;
+                PETHREAD Thread = nullptr;
+                NTSTATUS ReferenceStatus = ObReferenceObjectByHandle(
+                                               ThreadHandle,
+                                               0,
+                                               *PsThreadType,
+                                               ExGetPreviousMode(),
+                                               (PVOID*)&Thread,
+                                               nullptr);
+                if(NT_SUCCESS(ReferenceStatus))
+                {
+                    if(HasVirtualThreadHide(Thread))
+                        *(BOOLEAN*)ThreadInformation = TRUE;
+                    ObDereferenceObject(Thread);
+                }
 
                 RESTORE_RETURNLENGTH();
             }
@@ -158,7 +263,7 @@ static NTSTATUS NTAPI HookNtSetInformationThread(
     //Bug found by Aguila, thanks!
     if(ThreadInformationClass == ThreadHideFromDebugger && !ThreadInformationLength)
     {
-        if(Hider::IsHidden(pid, HideThreadHideFromDebugger))
+        if(gThreadNotifyRegistered && Hider::IsHidden(pid, HideThreadHideFromDebugger))
         {
             Log("[TITANHIDE] NtSetInformationThread(ThreadHideFromDebugger) by %d\r\n", pid);
             PETHREAD Thread;
@@ -169,7 +274,16 @@ static NTSTATUS NTAPI HookNtSetInformationThread(
                               (PVOID*)&Thread,
                               NULL);
             if(NT_SUCCESS(status))
+            {
+                const bool Registered = RegisterVirtualThreadHide(Thread);
                 ObDereferenceObject(Thread);
+                if(!Registered)
+                    return Undocumented::NtSetInformationThread(
+                               ThreadHandle,
+                               ThreadInformationClass,
+                               ThreadInformation,
+                               ThreadInformationLength);
+            }
             return status;
         }
     }
@@ -500,25 +614,49 @@ static NTSTATUS NTAPI HookNtQueryObject(
 
                 OBJECT_ALL_INFORMATION* pObjectAllInfo = (OBJECT_ALL_INFORMATION*)ObjectInformation;
                 unsigned char* pObjInfoLocation = (unsigned char*)pObjectAllInfo->ObjectTypeInformation;
+                unsigned char* BufferEnd = (unsigned char*)ObjectInformation + ObjectInformationLength;
+                if(BufferEnd < (unsigned char*)ObjectInformation)
+                {
+                    RESTORE_RETURNLENGTH();
+                    return ret;
+                }
+
                 unsigned int TotalObjects = pObjectAllInfo->NumberOfObjects;
                 for(unsigned int i = 0; i < TotalObjects; i++)
                 {
+                    if(pObjInfoLocation > BufferEnd ||
+                            (SIZE_T)(BufferEnd - pObjInfoLocation) < sizeof(OBJECT_TYPE_INFORMATION))
+                    {
+                        break;
+                    }
+
                     OBJECT_TYPE_INFORMATION* pObjectTypeInfo = (OBJECT_TYPE_INFORMATION*)pObjInfoLocation;
-                    ProbeForRead(pObjectTypeInfo, 1, 1);
-                    ProbeForRead(pObjectTypeInfo->TypeName.Buffer, 1, 1);
-                    if(RtlEqualUnicodeString(&pObjectTypeInfo->TypeName, &DebugObject, FALSE)) //DebugObject
+                    ProbeForRead(pObjectTypeInfo, sizeof(OBJECT_TYPE_INFORMATION), 1);
+
+                    // The name is inline after the fixed structure. TypeName.Buffer
+                    // may have been overwritten by an overlapping ReturnLength.
+                    unsigned char* InlineTypeName = (unsigned char*)(pObjectTypeInfo + 1);
+                    if(InlineTypeName > BufferEnd ||
+                            pObjectTypeInfo->TypeName.MaximumLength > (SIZE_T)(BufferEnd - InlineTypeName))
+                    {
+                        break;
+                    }
+
+                    if(pObjectTypeInfo->TypeName.Length == DebugObject.Length &&
+                            pObjectTypeInfo->TypeName.Length <= pObjectTypeInfo->TypeName.MaximumLength &&
+                            RtlCompareMemory(InlineTypeName, DebugObject.Buffer, DebugObject.Length) == DebugObject.Length)
                     {
                         Log("[TITANHIDE] DebugObject by %d\r\n", pid);
                         DEBUG_OBJECT_CONTRIBUTION Contribution;
                         if(QueryDebugObjectContribution(&Contribution))
                             RemoveDebugObjectContribution(pObjectTypeInfo, &Contribution);
                     }
-                    pObjInfoLocation = (unsigned char*)pObjectTypeInfo->TypeName.Buffer;
-                    pObjInfoLocation += pObjectTypeInfo->TypeName.MaximumLength;
-                    ULONG_PTR tmp = ((ULONG_PTR)pObjInfoLocation) & -(LONG_PTR)sizeof(void*);
-                    if((ULONG_PTR)tmp != (ULONG_PTR)pObjInfoLocation)
-                        tmp += sizeof(void*);
-                    pObjInfoLocation = ((unsigned char*)tmp);
+
+                    ULONG_PTR Next = (ULONG_PTR)InlineTypeName + pObjectTypeInfo->TypeName.MaximumLength;
+                    Next = (Next + sizeof(void*) - 1) & -(LONG_PTR)sizeof(void*);
+                    if(Next <= (ULONG_PTR)pObjInfoLocation || Next > (ULONG_PTR)BufferEnd)
+                        break;
+                    pObjInfoLocation = (unsigned char*)Next;
                 }
 
                 RESTORE_RETURNLENGTH();
@@ -675,8 +813,8 @@ static NTSTATUS NTAPI HookNtGetContextThread(
             ProbeForWrite(&Context->ContextFlags, sizeof(ULONG), 1);
             Context->ContextFlags = OriginalContextFlags;
 
-            // If debug registers were requested, zero user input
-            if(DebugRegistersRequested)
+            // Failed queries must leave the caller's output untouched.
+            if(NT_SUCCESS(ret) && DebugRegistersRequested)
             {
                 Context->Dr0 = 0;
                 Context->Dr1 = 0;
@@ -784,6 +922,10 @@ static NTSTATUS NTAPI HookNtCreateThreadEx(
 int Hooks::Initialize()
 {
     KeInitializeMutex(&gDebugPortMutex, 0);
+    KeInitializeSpinLock(&gVirtualThreadHideLock);
+    gVirtualThreadHideEntryCount = 0;
+    gThreadNotifyRegistered = NT_SUCCESS(PsSetCreateThreadNotifyRoutine(ThreadNotifyRoutine));
+
     int hook_count = 0;
     hNtQueryInformationProcess = SSDT::Hook("NtQueryInformationProcess", (void*)HookNtQueryInformationProcess);
     if(hNtQueryInformationProcess)
@@ -839,5 +981,17 @@ void Hooks::Deinitialize()
     if((NtBuildNumber & 0xFFFF) >= 6000)
     {
         SSDT::Unhook(hNtCreateThreadEx, true);
+    }
+
+    if(gThreadNotifyRegistered)
+    {
+        PsRemoveCreateThreadNotifyRoutine(ThreadNotifyRoutine);
+        gThreadNotifyRegistered = false;
+    }
+
+    while(gVirtualThreadHideEntryCount != 0)
+    {
+        PETHREAD Thread = gVirtualThreadHideEntries[--gVirtualThreadHideEntryCount].Thread;
+        ObDereferenceObject(Thread);
     }
 }

--- a/TitanHide/hooks.cpp
+++ b/TitanHide/hooks.cpp
@@ -280,7 +280,10 @@ static void InitializeDebugObjectTypeSignature()
     }
 }
 
-static void RemoveVirtualThreadHide(HANDLE ProcessId, HANDLE ThreadId)
+static void RemoveVirtualThreadHide(
+    HANDLE ProcessId,
+    HANDLE ThreadId,
+    bool RestoreState)
 {
     PETHREAD Thread = nullptr;
     KIRQL Irql;
@@ -291,6 +294,8 @@ static void RemoveVirtualThreadHide(HANDLE ProcessId, HANDLE ThreadId)
                 gVirtualThreadHideEntries[i].ThreadId == ThreadId)
         {
             Thread = gVirtualThreadHideEntries[i].Thread;
+            if(RestoreState)
+                RestoreHideFromDebugger(Thread);
             gVirtualThreadHideEntries[i] =
                 gVirtualThreadHideEntries[--gVirtualThreadHideEntryCount];
             break;
@@ -301,8 +306,16 @@ static void RemoveVirtualThreadHide(HANDLE ProcessId, HANDLE ThreadId)
         ObDereferenceObject(Thread);
 }
 
+bool Hooks::IsThreadHideVirtualizationAvailable()
+{
+    return gThreadNotifyRegistered;
+}
+
 bool Hooks::RegisterVirtualThreadHide(PETHREAD Thread)
 {
+    if(!gThreadNotifyRegistered)
+        return false;
+
     VIRTUAL_THREAD_HIDE_ENTRY Entry;
     Entry.ProcessId = PsGetProcessId(PsGetThreadProcess(Thread));
     Entry.ThreadId = PsGetThreadId(Thread);
@@ -330,8 +343,9 @@ bool Hooks::RegisterVirtualThreadHide(PETHREAD Thread)
     // If exit notification raced ahead of registration, remove the entry now.
     if(Registered && PsIsThreadTerminating(Thread))
     {
-        RemoveVirtualThreadHide(Entry.ProcessId, Entry.ThreadId);
-        return false;
+        RestoreHideFromDebugger(Thread);
+        RemoveVirtualThreadHide(Entry.ProcessId, Entry.ThreadId, false);
+        return true;
     }
 
     // Unhide can race with a set request. Preserve the native state rather than
@@ -341,7 +355,7 @@ bool Hooks::RegisterVirtualThreadHide(PETHREAD Thread)
                              HideThreadHideFromDebugger))
     {
         RestoreHideFromDebugger(Thread);
-        RemoveVirtualThreadHide(Entry.ProcessId, Entry.ThreadId);
+        RemoveVirtualThreadHide(Entry.ProcessId, Entry.ThreadId, false);
     }
     return Registered;
 }
@@ -395,7 +409,7 @@ static bool HasVirtualThreadHide(PETHREAD Thread)
 static void ThreadNotifyRoutine(HANDLE ProcessId, HANDLE ThreadId, BOOLEAN Create)
 {
     if(!Create)
-        RemoveVirtualThreadHide(ProcessId, ThreadId);
+        RemoveVirtualThreadHide(ProcessId, ThreadId, true);
 }
 
 static void RegisterCreatedVirtualThreadHide(PHANDLE ThreadHandle)

--- a/TitanHide/hooks.cpp
+++ b/TitanHide/hooks.cpp
@@ -22,15 +22,15 @@ static KMUTEX gDebugPortMutex;
 struct VIRTUAL_THREAD_HIDE_ENTRY
 {
     HANDLE ProcessId;
-    HANDLE ThreadId;
     PETHREAD Thread;
 };
 
+// Retain thread identity so an exited thread queried through an open handle
+// keeps its virtual state. Entries are released on unhide/unload and bounded.
 #define MAX_VIRTUAL_THREAD_HIDE_ENTRIES 4096
 static VIRTUAL_THREAD_HIDE_ENTRY gVirtualThreadHideEntries[MAX_VIRTUAL_THREAD_HIDE_ENTRIES];
 static ULONG gVirtualThreadHideEntryCount = 0;
 static KSPIN_LOCK gVirtualThreadHideLock;
-static bool gThreadNotifyRegistered = false;
 
 //https://forum.tuts4you.com/topic/40011-debugme-vmprotect-312-build-886-anti-debug-method-improved/#comment-192824
 //https://github.com/x64dbg/ScyllaHide/issues/47
@@ -280,45 +280,10 @@ static void InitializeDebugObjectTypeSignature()
     }
 }
 
-static void RemoveVirtualThreadHide(
-    HANDLE ProcessId,
-    HANDLE ThreadId,
-    bool RestoreState)
-{
-    PETHREAD Thread = nullptr;
-    KIRQL Irql;
-    KeAcquireSpinLock(&gVirtualThreadHideLock, &Irql);
-    for(ULONG i = 0; i < gVirtualThreadHideEntryCount; i++)
-    {
-        if(gVirtualThreadHideEntries[i].ProcessId == ProcessId &&
-                gVirtualThreadHideEntries[i].ThreadId == ThreadId)
-        {
-            Thread = gVirtualThreadHideEntries[i].Thread;
-            if(RestoreState)
-                RestoreHideFromDebugger(Thread);
-            gVirtualThreadHideEntries[i] =
-                gVirtualThreadHideEntries[--gVirtualThreadHideEntryCount];
-            break;
-        }
-    }
-    KeReleaseSpinLock(&gVirtualThreadHideLock, Irql);
-    if(Thread != nullptr)
-        ObDereferenceObject(Thread);
-}
-
-bool Hooks::IsThreadHideVirtualizationAvailable()
-{
-    return gThreadNotifyRegistered;
-}
-
 bool Hooks::RegisterVirtualThreadHide(PETHREAD Thread)
 {
-    if(!gThreadNotifyRegistered)
-        return false;
-
     VIRTUAL_THREAD_HIDE_ENTRY Entry;
     Entry.ProcessId = PsGetProcessId(PsGetThreadProcess(Thread));
-    Entry.ThreadId = PsGetThreadId(Thread);
     Entry.Thread = Thread;
 
     KIRQL Irql;
@@ -332,35 +297,49 @@ bool Hooks::RegisterVirtualThreadHide(PETHREAD Thread)
         }
     }
 
-    const bool Registered = gVirtualThreadHideEntryCount < MAX_VIRTUAL_THREAD_HIDE_ENTRIES;
+    // Prefer live-thread coverage when the bounded table is full. Evicting an
+    // exited entry can only affect a surviving handle after deliberate table
+    // exhaustion and never applies the physical one-way flag.
+    PETHREAD EvictedThread = nullptr;
+    if(gVirtualThreadHideEntryCount == MAX_VIRTUAL_THREAD_HIDE_ENTRIES)
+    {
+        for(ULONG i = 0; i < gVirtualThreadHideEntryCount; i++)
+        {
+            if(PsIsThreadTerminating(gVirtualThreadHideEntries[i].Thread))
+            {
+                EvictedThread = gVirtualThreadHideEntries[i].Thread;
+                gVirtualThreadHideEntries[i] =
+                    gVirtualThreadHideEntries[--gVirtualThreadHideEntryCount];
+                break;
+            }
+        }
+    }
+
+    const bool Registered =
+        gVirtualThreadHideEntryCount < MAX_VIRTUAL_THREAD_HIDE_ENTRIES;
     if(Registered)
     {
         ObReferenceObject(Thread);
         gVirtualThreadHideEntries[gVirtualThreadHideEntryCount++] = Entry;
     }
     KeReleaseSpinLock(&gVirtualThreadHideLock, Irql);
+    if(EvictedThread != nullptr)
+        ObDereferenceObject(EvictedThread);
 
-    // If exit notification raced ahead of registration, remove the entry now.
-    if(Registered && PsIsThreadTerminating(Thread))
-    {
-        RestoreHideFromDebugger(Thread);
-        RemoveVirtualThreadHide(Entry.ProcessId, Entry.ThreadId, false);
-        return true;
-    }
-
-    // Unhide can race with a set request. Preserve the native state rather than
-    // leaving an untracked thread with its physical flag cleared.
+    // Unhide can race with registration. Clear the virtual state if protection
+    // ended; never apply a delayed physical HideFromDebugger request.
     if(Registered &&
             !Hider::IsHidden((ULONG)(ULONG_PTR)Entry.ProcessId,
                              HideThreadHideFromDebugger))
     {
-        RestoreHideFromDebugger(Thread);
-        RemoveVirtualThreadHide(Entry.ProcessId, Entry.ThreadId, false);
+        Hooks::ClearVirtualThreadHides(
+            (ULONG)(ULONG_PTR)Entry.ProcessId,
+            false);
     }
     return Registered;
 }
 
-void Hooks::RestoreVirtualThreadHides(ULONG ProcessId, bool AllProcesses)
+void Hooks::ClearVirtualThreadHides(ULONG ProcessId, bool AllProcesses)
 {
     while(true)
     {
@@ -374,8 +353,6 @@ void Hooks::RestoreVirtualThreadHides(ULONG ProcessId, bool AllProcesses)
                         (HANDLE)(ULONG_PTR)ProcessId)
             {
                 Thread = gVirtualThreadHideEntries[i].Thread;
-                if(!PsIsThreadTerminating(Thread))
-                    RestoreHideFromDebugger(Thread);
                 gVirtualThreadHideEntries[i] =
                     gVirtualThreadHideEntries[--gVirtualThreadHideEntryCount];
                 break;
@@ -406,12 +383,6 @@ static bool HasVirtualThreadHide(PETHREAD Thread)
     return Found;
 }
 
-static void ThreadNotifyRoutine(HANDLE ProcessId, HANDLE ThreadId, BOOLEAN Create)
-{
-    if(!Create)
-        RemoveVirtualThreadHide(ProcessId, ThreadId, true);
-}
-
 static void RegisterCreatedVirtualThreadHide(PHANDLE ThreadHandle)
 {
     __try
@@ -429,8 +400,9 @@ static void RegisterCreatedVirtualThreadHide(PHANDLE ThreadHandle)
                               nullptr);
         if(NT_SUCCESS(Status))
         {
-            if(!Hooks::RegisterVirtualThreadHide(Thread))
-                RestoreHideFromDebugger(Thread);
+            // Keep the physical flag clear even if the bounded virtual-state
+            // table is exhausted. Debugger visibility takes precedence.
+            Hooks::RegisterVirtualThreadHide(Thread);
             ObDereferenceObject(Thread);
         }
     }
@@ -515,8 +487,7 @@ static NTSTATUS NTAPI HookNtQueryInformationThread(
     NTSTATUS Status = Undocumented::NtQueryInformationThread(ThreadHandle, ThreadInformationClass, ThreadInformation, ThreadInformationLength, ReturnLength);
 
     if(NT_SUCCESS(Status) &&
-            ThreadInformationClass == ThreadHideFromDebugger &&
-            gThreadNotifyRegistered)
+            ThreadInformationClass == ThreadHideFromDebugger)
     {
         __try
         {
@@ -570,8 +541,7 @@ static NTSTATUS NTAPI HookNtSetInformationThread(
     //Bug found by Aguila, thanks!
     if(ThreadInformationClass == ThreadHideFromDebugger && !ThreadInformationLength)
     {
-        if(gThreadNotifyRegistered &&
-                Hider::IsHidden(pid, HideThreadHideFromDebugger) &&
+        if(Hider::IsHidden(pid, HideThreadHideFromDebugger) &&
                 Hider::IsHidden(targetPid, HideThreadHideFromDebugger))
         {
             Log("[TITANHIDE] NtSetInformationThread(ThreadHideFromDebugger) by %d\r\n", pid);
@@ -584,14 +554,10 @@ static NTSTATUS NTAPI HookNtSetInformationThread(
                               NULL);
             if(NT_SUCCESS(status))
             {
-                const bool Registered = Hooks::RegisterVirtualThreadHide(Thread);
+                // Never fall back to the real set operation: the flag is
+                // one-way and would hide this thread from the debugger.
+                Hooks::RegisterVirtualThreadHide(Thread);
                 ObDereferenceObject(Thread);
-                if(!Registered)
-                    return Undocumented::NtSetInformationThread(
-                               ThreadHandle,
-                               ThreadInformationClass,
-                               ThreadInformation,
-                               ThreadInformationLength);
             }
             return status;
         }
@@ -1361,7 +1327,6 @@ static NTSTATUS NTAPI HookNtCreateThreadEx(
     const ULONG pid = (ULONG)(ULONG_PTR)PsGetCurrentProcessId();
     const ULONG targetPid = Misc::GetProcessIDFromProcessHandle(ProcessHandle);
     const bool VirtualizeThreadHide =
-        gThreadNotifyRegistered &&
         (CreateFlags & THREAD_CREATE_FLAGS_HIDE_FROM_DEBUGGER) != 0 &&
         Hider::IsHidden(pid, HideThreadHideFromDebugger) &&
         Hider::IsHidden(targetPid, HideThreadHideFromDebugger);
@@ -1394,7 +1359,6 @@ int Hooks::Initialize()
     KeInitializeMutex(&gDebugPortMutex, 0);
     KeInitializeSpinLock(&gVirtualThreadHideLock);
     gVirtualThreadHideEntryCount = 0;
-    gThreadNotifyRegistered = NT_SUCCESS(PsSetCreateThreadNotifyRoutine(ThreadNotifyRoutine));
 
     int hook_count = 0;
     hNtQueryInformationProcess = SSDT::Hook("NtQueryInformationProcess", (void*)HookNtQueryInformationProcess);
@@ -1453,11 +1417,5 @@ void Hooks::Deinitialize()
         SSDT::Unhook(hNtCreateThreadEx, true);
     }
 
-    if(gThreadNotifyRegistered)
-    {
-        PsRemoveCreateThreadNotifyRoutine(ThreadNotifyRoutine);
-        gThreadNotifyRegistered = false;
-    }
-
-    RestoreVirtualThreadHides(0, true);
+    ClearVirtualThreadHides(0, true);
 }

--- a/TitanHide/hooks.cpp
+++ b/TitanHide/hooks.cpp
@@ -89,7 +89,7 @@ static void RemoveVirtualThreadHide(HANDLE ProcessId, HANDLE ThreadId)
         ObDereferenceObject(Thread);
 }
 
-static bool RegisterVirtualThreadHide(PETHREAD Thread)
+bool Hooks::RegisterVirtualThreadHide(PETHREAD Thread)
 {
     VIRTUAL_THREAD_HIDE_ENTRY Entry;
     Entry.ProcessId = PsGetProcessId(PsGetThreadProcess(Thread));
@@ -275,7 +275,7 @@ static NTSTATUS NTAPI HookNtSetInformationThread(
                               NULL);
             if(NT_SUCCESS(status))
             {
-                const bool Registered = RegisterVirtualThreadHide(Thread);
+                const bool Registered = Hooks::RegisterVirtualThreadHide(Thread);
                 ObDereferenceObject(Thread);
                 if(!Registered)
                     return Undocumented::NtSetInformationThread(

--- a/TitanHide/hooks.h
+++ b/TitanHide/hooks.h
@@ -9,8 +9,7 @@ public:
     static int Initialize();
     static void Deinitialize();
     static bool RegisterVirtualThreadHide(PETHREAD Thread);
-    static bool IsThreadHideVirtualizationAvailable();
-    static void RestoreVirtualThreadHides(ULONG ProcessId, bool AllProcesses);
+    static void ClearVirtualThreadHides(ULONG ProcessId, bool AllProcesses);
 };
 
 #endif

--- a/TitanHide/hooks.h
+++ b/TitanHide/hooks.h
@@ -9,6 +9,7 @@ public:
     static int Initialize();
     static void Deinitialize();
     static bool RegisterVirtualThreadHide(PETHREAD Thread);
+    static bool IsThreadHideVirtualizationAvailable();
     static void RestoreVirtualThreadHides(ULONG ProcessId, bool AllProcesses);
 };
 

--- a/TitanHide/hooks.h
+++ b/TitanHide/hooks.h
@@ -9,6 +9,7 @@ public:
     static int Initialize();
     static void Deinitialize();
     static bool RegisterVirtualThreadHide(PETHREAD Thread);
+    static void RestoreVirtualThreadHides(ULONG ProcessId, bool AllProcesses);
 };
 
 #endif

--- a/TitanHide/hooks.h
+++ b/TitanHide/hooks.h
@@ -8,6 +8,7 @@ class Hooks
 public:
     static int Initialize();
     static void Deinitialize();
+    static bool RegisterVirtualThreadHide(PETHREAD Thread);
 };
 
 #endif

--- a/TitanHide/threadhidefromdbg.cpp
+++ b/TitanHide/threadhidefromdbg.cpp
@@ -1,5 +1,6 @@
 #include "threadhidefromdbg.h"
 #include "undocumented.h"
+#include "hooks.h"
 #include "log.h"
 
 // Exclude false positive matches in the KTHREAD/Tcb header
@@ -240,9 +241,18 @@ NTSTATUS UndoHideFromDebuggerInRunningThreads(_In_ ULONG Pid)
                     LONG* CrossThreadFlagsAddress = (LONG*)((ULONG_PTR)Thread + CrossThreadFlagsOffset);
                     if((InterlockedAnd(CrossThreadFlagsAddress, ~PS_CROSS_THREAD_FLAGS_HIDEFROMDBG) & PS_CROSS_THREAD_FLAGS_HIDEFROMDBG) != 0)
                     {
-                        NumThreadFlagsStripped++;
-                        Log("[TITANHIDE] Stripped ThreadHideFromDebugger flag from PID %u, TID %u!\r\n",
-                            Pid, (ULONG)(ULONG_PTR)Entry->Threads[i].ClientId.UniqueThread);
+                        if(Hooks::RegisterVirtualThreadHide(Thread))
+                        {
+                            NumThreadFlagsStripped++;
+                            Log("[TITANHIDE] Stripped ThreadHideFromDebugger flag from PID %u, TID %u!\r\n",
+                                Pid, (ULONG)(ULONG_PTR)Entry->Threads[i].ClientId.UniqueThread);
+                        }
+                        else
+                        {
+                            // Keep native observable state if virtualization could
+                            // not be registered.
+                            InterlockedOr(CrossThreadFlagsAddress, PS_CROSS_THREAD_FLAGS_HIDEFROMDBG);
+                        }
                     }
                     ObDereferenceObject(Thread);
                 }

--- a/TitanHide/threadhidefromdbg.cpp
+++ b/TitanHide/threadhidefromdbg.cpp
@@ -193,9 +193,8 @@ Exit:
     return Status;
 }
 
-// The NtQueryInformationThread hook prevents a process from enabling ThreadHideFromDebugger on
-// new threads, but there is no kernel API to disable this flag on threads that already have it.
-// This function uses DKOM to strip the HideFromDebugger flag from all threads in a process.
+// Reapply a preexisting flag only as immediate rollback when a DKOM clear
+// cannot be virtualized. Intercepted set/create requests never call this.
 VOID RestoreHideFromDebugger(_In_ PETHREAD Thread)
 {
     if(CrossThreadFlagsOffset != 0)
@@ -205,6 +204,8 @@ VOID RestoreHideFromDebugger(_In_ PETHREAD Thread)
     }
 }
 
+// There is no kernel API to clear HideFromDebugger on threads that already
+// have it, so use DKOM and preserve its observable query state virtually.
 NTSTATUS UndoHideFromDebuggerInRunningThreads(_In_ ULONG Pid)
 {
     PSYSTEM_PROCESS_INFORMATION SystemProcessInfo = nullptr, Entry;

--- a/TitanHide/threadhidefromdbg.cpp
+++ b/TitanHide/threadhidefromdbg.cpp
@@ -213,8 +213,6 @@ NTSTATUS UndoHideFromDebuggerInRunningThreads(_In_ ULONG Pid)
 
     if(CrossThreadFlagsOffset == 0)
         return STATUS_NOT_FOUND;
-    if(!Hooks::IsThreadHideVirtualizationAvailable())
-        return STATUS_NOT_SUPPORTED;
 
     PEPROCESS Process;
     NTSTATUS Status = PsLookupProcessByProcessId((HANDLE)(ULONG_PTR)Pid, &Process);

--- a/TitanHide/threadhidefromdbg.cpp
+++ b/TitanHide/threadhidefromdbg.cpp
@@ -213,6 +213,8 @@ NTSTATUS UndoHideFromDebuggerInRunningThreads(_In_ ULONG Pid)
 
     if(CrossThreadFlagsOffset == 0)
         return STATUS_NOT_FOUND;
+    if(!Hooks::IsThreadHideVirtualizationAvailable())
+        return STATUS_NOT_SUPPORTED;
 
     PEPROCESS Process;
     NTSTATUS Status = PsLookupProcessByProcessId((HANDLE)(ULONG_PTR)Pid, &Process);

--- a/TitanHide/threadhidefromdbg.cpp
+++ b/TitanHide/threadhidefromdbg.cpp
@@ -196,6 +196,15 @@ Exit:
 // The NtQueryInformationThread hook prevents a process from enabling ThreadHideFromDebugger on
 // new threads, but there is no kernel API to disable this flag on threads that already have it.
 // This function uses DKOM to strip the HideFromDebugger flag from all threads in a process.
+VOID RestoreHideFromDebugger(_In_ PETHREAD Thread)
+{
+    if(CrossThreadFlagsOffset != 0)
+    {
+        LONG* CrossThreadFlagsAddress = (LONG*)((ULONG_PTR)Thread + CrossThreadFlagsOffset);
+        InterlockedOr(CrossThreadFlagsAddress, PS_CROSS_THREAD_FLAGS_HIDEFROMDBG);
+    }
+}
+
 NTSTATUS UndoHideFromDebuggerInRunningThreads(_In_ ULONG Pid)
 {
     PSYSTEM_PROCESS_INFORMATION SystemProcessInfo = nullptr, Entry;
@@ -251,7 +260,7 @@ NTSTATUS UndoHideFromDebuggerInRunningThreads(_In_ ULONG Pid)
                         {
                             // Keep native observable state if virtualization could
                             // not be registered.
-                            InterlockedOr(CrossThreadFlagsAddress, PS_CROSS_THREAD_FLAGS_HIDEFROMDBG);
+                            RestoreHideFromDebugger(Thread);
                         }
                     }
                     ObDereferenceObject(Thread);

--- a/TitanHide/threadhidefromdbg.h
+++ b/TitanHide/threadhidefromdbg.h
@@ -7,5 +7,6 @@ extern ULONG CrossThreadFlagsOffset;
 extern "C"
 {
     NTSTATUS FindCrossThreadFlagsOffset(_Out_ PULONG Offset);
+    VOID RestoreHideFromDebugger(_In_ PETHREAD Thread);
     NTSTATUS UndoHideFromDebuggerInRunningThreads(_In_ ULONG Pid);
 }

--- a/TitanHideTest/main.cpp
+++ b/TitanHideTest/main.cpp
@@ -258,12 +258,17 @@ bool CheckThreadHideFromDebuggerContract()
         HANDLE, ULONG, PVOID, ULONG, PULONG);
     typedef NTSTATUS(NTAPI * NT_SET_INFORMATION_THREAD)(
         HANDLE, ULONG, PVOID, ULONG);
+    typedef NTSTATUS(NTAPI * NT_CREATE_THREAD_EX)(
+        PHANDLE, ACCESS_MASK, PVOID, HANDLE, PVOID, PVOID, ULONG,
+        SIZE_T, SIZE_T, SIZE_T, PVOID);
 
     NT_QUERY_INFORMATION_THREAD NtQIT = (NT_QUERY_INFORMATION_THREAD)
             GetProcAddress(GetModuleHandle(TEXT("ntdll.dll")), "NtQueryInformationThread");
     NT_SET_INFORMATION_THREAD NtSIT = (NT_SET_INFORMATION_THREAD)
             GetProcAddress(GetModuleHandle(TEXT("ntdll.dll")), "NtSetInformationThread");
-    if(NtQIT == nullptr || NtSIT == nullptr)
+    NT_CREATE_THREAD_EX NtCTE = (NT_CREATE_THREAD_EX)
+            GetProcAddress(GetModuleHandle(TEXT("ntdll.dll")), "NtCreateThreadEx");
+    if(NtQIT == nullptr || NtSIT == nullptr || NtCTE == nullptr)
         return false;
 
     HANDLE Thread = CreateThread(nullptr, 0, ContractThreadProc, nullptr, CREATE_SUSPENDED, nullptr);
@@ -294,6 +299,41 @@ bool CheckThreadHideFromDebuggerContract()
     if(!NT_SUCCESS(Status) || Hidden != TRUE || ReturnLength != sizeof(Hidden))
     {
         printf("ThreadHideFromDebugger virtual-state mismatch: %08X, %u, %u\n",
+               Status, Hidden, ReturnLength);
+        Detected = true;
+    }
+
+    TerminateThread(Thread, 0);
+    CloseHandle(Thread);
+
+    // A thread created with the hide flag has the same observable state as one
+    // hidden later through NtSetInformationThread.
+    const ULONG ThreadCreateFlagsCreateSuspended = 0x1;
+    const ULONG ThreadCreateFlagsHideFromDebugger = 0x4;
+    Thread = nullptr;
+    Status = NtCTE(&Thread,
+                   THREAD_ALL_ACCESS,
+                   nullptr,
+                   GetCurrentProcess(),
+                   (PVOID)ContractThreadProc,
+                   nullptr,
+                   ThreadCreateFlagsCreateSuspended | ThreadCreateFlagsHideFromDebugger,
+                   0,
+                   0,
+                   0,
+                   nullptr);
+    if(!NT_SUCCESS(Status) || Thread == nullptr)
+    {
+        printf("NtCreateThreadEx hide-state setup failed: %08X\n", Status);
+        return true;
+    }
+
+    Hidden = FALSE;
+    ReturnLength = 0;
+    Status = NtQIT(Thread, 0x11, &Hidden, sizeof(Hidden), &ReturnLength);
+    if(!NT_SUCCESS(Status) || Hidden != TRUE || ReturnLength != sizeof(Hidden))
+    {
+        printf("NtCreateThreadEx hide-state mismatch: %08X, %u, %u\n",
                Status, Hidden, ReturnLength);
         Detected = true;
     }
@@ -340,6 +380,26 @@ typedef struct _OBJECT_TYPE_INFORMATION
     UNICODE_STRING TypeName;
     ULONG TotalNumberOfObjects;
     ULONG TotalNumberOfHandles;
+    ULONG TotalPagedPoolUsage;
+    ULONG TotalNonPagedPoolUsage;
+    ULONG TotalNamePoolUsage;
+    ULONG TotalHandleTableUsage;
+    ULONG HighWaterNumberOfObjects;
+    ULONG HighWaterNumberOfHandles;
+    ULONG HighWaterPagedPoolUsage;
+    ULONG HighWaterNonPagedPoolUsage;
+    ULONG HighWaterNamePoolUsage;
+    ULONG HighWaterHandleTableUsage;
+    ULONG InvalidAttributes;
+    GENERIC_MAPPING GenericMapping;
+    ULONG ValidAccessMask;
+    BOOLEAN SecurityRequired;
+    BOOLEAN MaintainHandleCount;
+    UCHAR TypeIndex;
+    CHAR ReservedByte;
+    ULONG PoolType;
+    ULONG DefaultPagedPoolCharge;
+    ULONG DefaultNonPagedPoolCharge;
 } OBJECT_TYPE_INFORMATION, *POBJECT_TYPE_INFORMATION;
 
 typedef struct _OBJECT_ALL_INFORMATION
@@ -588,7 +648,9 @@ bool CheckObjectTypesInformationOverlapContract()
 
     OBJECT_ALL_INFORMATION* All = (OBJECT_ALL_INFORMATION*)Buffer;
     unsigned char* Location = (unsigned char*)All->ObjectTypeInformation;
-    PULONG Overlap = nullptr;
+    SIZE_T DebugObjectOffset = (SIZE_T)-1;
+    SIZE_T PreviousObjectOffset = (SIZE_T)-1;
+    SIZE_T PreviousOffset = (SIZE_T)-1;
     const wchar_t DebugObject[] = L"DebugObject";
     const USHORT DebugObjectLength = sizeof(DebugObject) - sizeof(wchar_t);
     for(ULONG i = 0; i < All->NumberOfObjects; i++)
@@ -597,24 +659,51 @@ bool CheckObjectTypesInformationOverlapContract()
         if(Type->TypeName.Length == DebugObjectLength &&
                 memcmp(Type->TypeName.Buffer, DebugObject, DebugObjectLength) == 0)
         {
-            Overlap = (PULONG)&Type->TypeName.Buffer;
+            DebugObjectOffset = (SIZE_T)(Location - Buffer);
+            PreviousObjectOffset = PreviousOffset;
             break;
         }
+        PreviousOffset = (SIZE_T)(Location - Buffer);
         Location = (unsigned char*)Type->TypeName.Buffer + Type->TypeName.MaximumLength;
         Location = (unsigned char*)(((ULONG_PTR)Location + sizeof(void*) - 1) &
                                     -(LONG_PTR)sizeof(void*));
     }
 
-    bool Detected = Overlap == nullptr;
-    if(Overlap == nullptr)
-        puts("ObjectTypesInformation did not contain DebugObject");
-    if(Overlap != nullptr)
+    bool Detected = DebugObjectOffset == (SIZE_T)-1 ||
+                    PreviousObjectOffset == (SIZE_T)-1;
+    if(Detected)
+        puts("ObjectTypesInformation did not contain a preceding DebugObject entry");
+    if(!Detected)
     {
-        Status = NtQO(nullptr, ObjectTypesInformation, Buffer, BufferSize, Overlap);
-        if(!NT_SUCCESS(Status) || *Overlap != ActualLength)
+        const SIZE_T OverlapOffsets[] =
         {
-            printf("ObjectTypesInformation overlap contract mismatch: %08X\n", Status);
-            Detected = true;
+            DebugObjectOffset + FIELD_OFFSET(OBJECT_TYPE_INFORMATION, TypeName.Buffer),
+            PreviousObjectOffset + FIELD_OFFSET(OBJECT_TYPE_INFORMATION, TypeName.MaximumLength),
+            DebugObjectOffset + sizeof(OBJECT_TYPE_INFORMATION),
+            DebugObjectOffset + FIELD_OFFSET(OBJECT_TYPE_INFORMATION, TypeIndex)
+        };
+        for(ULONG i = 0; i < ARRAYSIZE(OverlapOffsets); i++)
+        {
+            ULONG NewActualLength = 0;
+            Status = NtQO(nullptr,
+                          ObjectTypesInformation,
+                          Buffer,
+                          BufferSize,
+                          &NewActualLength);
+            if(!NT_SUCCESS(Status))
+            {
+                printf("ObjectTypesInformation overlap reset failed: %08X\n", Status);
+                Detected = true;
+                break;
+            }
+
+            PULONG Overlap = (PULONG)(Buffer + OverlapOffsets[i]);
+            Status = NtQO(nullptr, ObjectTypesInformation, Buffer, BufferSize, Overlap);
+            if(!NT_SUCCESS(Status) || *Overlap != NewActualLength)
+            {
+                printf("ObjectTypesInformation overlap %u mismatch: %08X\n", i, Status);
+                Detected = true;
+            }
         }
     }
 

--- a/TitanHideTest/main.cpp
+++ b/TitanHideTest/main.cpp
@@ -717,6 +717,63 @@ bool CheckObjectTypesInformationOverlapContract()
         }
     }
 
+    // Bytes after the native object-type list are caller-owned even when the
+    // supplied allocation is larger than ReturnLength. A filter must not scan
+    // or modify a crafted entry in that tail.
+    ULONG TailActualLength = 0;
+    Status = NtQO(nullptr,
+                  ObjectTypesInformation,
+                  Buffer,
+                  BufferSize,
+                  &TailActualLength);
+    if(NT_SUCCESS(Status))
+    {
+        All = (OBJECT_ALL_INFORMATION*)Buffer;
+        Location = (unsigned char*)All->ObjectTypeInformation;
+        for(ULONG i = 0; i < All->NumberOfObjects; i++)
+        {
+            OBJECT_TYPE_INFORMATION* Type = (OBJECT_TYPE_INFORMATION*)Location;
+            Location = (unsigned char*)Type->TypeName.Buffer +
+                       Type->TypeName.MaximumLength;
+            Location = (unsigned char*)(((ULONG_PTR)Location + sizeof(void*) - 1) &
+                                        -(LONG_PTR)sizeof(void*));
+        }
+
+        const SIZE_T FakeSize = sizeof(OBJECT_TYPE_INFORMATION) + sizeof(DebugObject);
+        if(Location >= Buffer + TailActualLength &&
+                Location + FakeSize <= Buffer + BufferSize)
+        {
+            OBJECT_TYPE_INFORMATION* Fake =
+                (OBJECT_TYPE_INFORMATION*)Location;
+            memset(Fake, 0, FakeSize);
+            Fake->TypeName.Buffer = (PWSTR)(Fake + 1);
+            Fake->TypeName.Length = DebugObjectLength;
+            Fake->TypeName.MaximumLength = sizeof(DebugObject);
+            Fake->TotalNumberOfObjects = 0xA1B2C3D4;
+            Fake->TotalNumberOfHandles = 0xB1C2D3E4;
+            memcpy(Fake->TypeName.Buffer, DebugObject, sizeof(DebugObject));
+
+            unsigned char Expected[sizeof(OBJECT_TYPE_INFORMATION) + sizeof(DebugObject)];
+            memcpy(Expected, Fake, sizeof(Expected));
+            Status = NtQO(nullptr,
+                          ObjectTypesInformation,
+                          Buffer,
+                          BufferSize,
+                          &TailActualLength);
+            if(!NT_SUCCESS(Status) ||
+                    memcmp(Fake, Expected, sizeof(Expected)) != 0)
+            {
+                printf("ObjectTypesInformation tail contract mismatch: %08X\n", Status);
+                Detected = true;
+            }
+        }
+    }
+    else
+    {
+        printf("ObjectTypesInformation tail setup failed: %08X\n", Status);
+        Detected = true;
+    }
+
     HeapFree(GetProcessHeap(), 0, Buffer);
     return Detected;
 }

--- a/TitanHideTest/main.cpp
+++ b/TitanHideTest/main.cpp
@@ -247,6 +247,94 @@ bool HideFromDebugger()
                             0));
 }
 
+static DWORD WINAPI ContractThreadProc(PVOID)
+{
+    return 0;
+}
+
+bool CheckThreadHideFromDebuggerContract()
+{
+    typedef NTSTATUS(NTAPI * NT_QUERY_INFORMATION_THREAD)(
+        HANDLE, ULONG, PVOID, ULONG, PULONG);
+    typedef NTSTATUS(NTAPI * NT_SET_INFORMATION_THREAD)(
+        HANDLE, ULONG, PVOID, ULONG);
+
+    NT_QUERY_INFORMATION_THREAD NtQIT = (NT_QUERY_INFORMATION_THREAD)
+            GetProcAddress(GetModuleHandle(TEXT("ntdll.dll")), "NtQueryInformationThread");
+    NT_SET_INFORMATION_THREAD NtSIT = (NT_SET_INFORMATION_THREAD)
+            GetProcAddress(GetModuleHandle(TEXT("ntdll.dll")), "NtSetInformationThread");
+    if(NtQIT == nullptr || NtSIT == nullptr)
+        return false;
+
+    HANDLE Thread = CreateThread(nullptr, 0, ContractThreadProc, nullptr, CREATE_SUSPENDED, nullptr);
+    if(Thread == nullptr)
+        return false;
+
+    bool Detected = false;
+    BOOLEAN Hidden = TRUE;
+    ULONG ReturnLength = 0;
+    NTSTATUS Status = NtQIT(Thread, 0x11, &Hidden, sizeof(Hidden), &ReturnLength);
+    if(!NT_SUCCESS(Status) || Hidden != FALSE || ReturnLength != sizeof(Hidden))
+    {
+        printf("ThreadHideFromDebugger initial-state mismatch: %08X, %u, %u\n",
+               Status, Hidden, ReturnLength);
+        Detected = true;
+    }
+
+    Status = NtSIT(Thread, 0x11, nullptr, 0);
+    if(!NT_SUCCESS(Status))
+    {
+        printf("ThreadHideFromDebugger set failed: %08X\n", Status);
+        Detected = true;
+    }
+
+    Hidden = FALSE;
+    ReturnLength = 0;
+    Status = NtQIT(Thread, 0x11, &Hidden, sizeof(Hidden), &ReturnLength);
+    if(!NT_SUCCESS(Status) || Hidden != TRUE || ReturnLength != sizeof(Hidden))
+    {
+        printf("ThreadHideFromDebugger virtual-state mismatch: %08X, %u, %u\n",
+               Status, Hidden, ReturnLength);
+        Detected = true;
+    }
+
+    TerminateThread(Thread, 0);
+    CloseHandle(Thread);
+    return Detected;
+}
+
+bool CheckGetContextFailureContract()
+{
+    typedef NTSTATUS(NTAPI * NT_GET_CONTEXT_THREAD)(HANDLE, PCONTEXT);
+    NT_GET_CONTEXT_THREAD NtGCT = (NT_GET_CONTEXT_THREAD)
+            GetProcAddress(GetModuleHandle(TEXT("ntdll.dll")), "NtGetContextThread");
+    if(NtGCT == nullptr)
+        return false;
+
+    HANDLE LimitedThread = OpenThread(THREAD_QUERY_LIMITED_INFORMATION,
+                                      FALSE,
+                                      GetCurrentThreadId());
+    if(LimitedThread == nullptr)
+        return false;
+
+    __declspec(align(16)) CONTEXT Context;
+    memset(&Context, 0xA5, sizeof(Context));
+    Context.ContextFlags = CONTEXT_DEBUG_REGISTERS;
+    CONTEXT OriginalContext;
+    memcpy(&OriginalContext, &Context, sizeof(Context));
+
+    NTSTATUS Status = NtGCT(LimitedThread, &Context);
+    CloseHandle(LimitedThread);
+
+    const NTSTATUS StatusAccessDenied = (NTSTATUS)0xC0000022L;
+    if(Status != StatusAccessDenied || memcmp(&Context, &OriginalContext, sizeof(Context)) != 0)
+    {
+        printf("NtGetContextThread failure contract mismatch: %08X\n", Status);
+        return true;
+    }
+    return false;
+}
+
 typedef struct _OBJECT_TYPE_INFORMATION
 {
     UNICODE_STRING TypeName;
@@ -469,6 +557,71 @@ bool CheckObjectList()
     }
 }
 
+bool CheckObjectTypesInformationOverlapContract()
+{
+    typedef NTSTATUS(NTAPI * pNtQueryObject)(
+        HANDLE, OBJECT_INFORMATION_CLASS, PVOID, ULONG, PULONG);
+    pNtQueryObject NtQO = (pNtQueryObject)GetProcAddress(
+                              GetModuleHandle(TEXT("ntdll.dll")),
+                              "NtQueryObject");
+    if(NtQO == nullptr)
+        return false;
+
+    ULONG Size = 0;
+    NTSTATUS Status = NtQO(nullptr, ObjectTypesInformation, nullptr, 0, &Size);
+    if(Status != (NTSTATUS)0xC0000004L || Size == 0)
+        return false;
+
+    const ULONG BufferSize = Size + 0x10000;
+    unsigned char* Buffer = (unsigned char*)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, BufferSize);
+    if(Buffer == nullptr)
+        return false;
+
+    ULONG ActualLength = 0;
+    Status = NtQO(nullptr, ObjectTypesInformation, Buffer, BufferSize, &ActualLength);
+    if(!NT_SUCCESS(Status))
+    {
+        printf("ObjectTypesInformation baseline query failed: %08X\n", Status);
+        HeapFree(GetProcessHeap(), 0, Buffer);
+        return true;
+    }
+
+    OBJECT_ALL_INFORMATION* All = (OBJECT_ALL_INFORMATION*)Buffer;
+    unsigned char* Location = (unsigned char*)All->ObjectTypeInformation;
+    PULONG Overlap = nullptr;
+    const wchar_t DebugObject[] = L"DebugObject";
+    const USHORT DebugObjectLength = sizeof(DebugObject) - sizeof(wchar_t);
+    for(ULONG i = 0; i < All->NumberOfObjects; i++)
+    {
+        OBJECT_TYPE_INFORMATION* Type = (OBJECT_TYPE_INFORMATION*)Location;
+        if(Type->TypeName.Length == DebugObjectLength &&
+                memcmp(Type->TypeName.Buffer, DebugObject, DebugObjectLength) == 0)
+        {
+            Overlap = (PULONG)&Type->TypeName.Buffer;
+            break;
+        }
+        Location = (unsigned char*)Type->TypeName.Buffer + Type->TypeName.MaximumLength;
+        Location = (unsigned char*)(((ULONG_PTR)Location + sizeof(void*) - 1) &
+                                    -(LONG_PTR)sizeof(void*));
+    }
+
+    bool Detected = Overlap == nullptr;
+    if(Overlap == nullptr)
+        puts("ObjectTypesInformation did not contain DebugObject");
+    if(Overlap != nullptr)
+    {
+        Status = NtQO(nullptr, ObjectTypesInformation, Buffer, BufferSize, Overlap);
+        if(!NT_SUCCESS(Status) || *Overlap != ActualLength)
+        {
+            printf("ObjectTypesInformation overlap contract mismatch: %08X\n", Status);
+            Detected = true;
+        }
+    }
+
+    HeapFree(GetProcessHeap(), 0, Buffer);
+    return Detected;
+}
+
 enum PROCESSINFOCLASS
 {
     ProcessBasicInformation = 0, // 0, q: PROCESS_BASIC_INFORMATION, PROCESS_EXTENDED_BASIC_INFORMATION
@@ -605,8 +758,16 @@ bool CheckNtClose()
 
 int main(int argc, char* argv[])
 {
-    if(argc == 2 && strcmp(argv[1], "--process-debug-object-contract") == 0)
-        return CheckProcessDebugObjectHandle() ? 1 : 0;
+    if(argc == 2 && strcmp(argv[1], "--native-contracts") == 0)
+    {
+        const bool ProcessDebugObject = CheckProcessDebugObjectHandle();
+        const bool ThreadHide = CheckThreadHideFromDebuggerContract();
+        const bool GetContextFailure = CheckGetContextFailureContract();
+        const bool ObjectTypesOverlap = CheckObjectTypesInformationOverlapContract();
+        printf("Native contracts: ProcessDebugObject=%d ThreadHide=%d GetContextFailure=%d ObjectTypesOverlap=%d\n",
+               ProcessDebugObject, ThreadHide, GetContextFailure, ObjectTypesOverlap);
+        return ProcessDebugObject || ThreadHide || GetContextFailure || ObjectTypesOverlap ? 1 : 0;
+    }
 
     char title[256] = "";
     sprintf_s(title, "pid: %d", (int)GetCurrentProcessId());

--- a/TitanHideTest/main.cpp
+++ b/TitanHideTest/main.cpp
@@ -1,5 +1,6 @@
 #include <windows.h>
 #include <stdio.h>
+#include <string.h>
 #include <Subauth.h>
 #include "..\TitanHide\TitanHide.h"
 
@@ -72,39 +73,161 @@ bool CheckProcessDebugPort()
 
 bool CheckProcessDebugObjectHandle()
 {
-    // Much easier in ASM but C/C++ looks so much better
-    typedef int (WINAPI * pNtQueryInformationProcess)
+    typedef NTSTATUS(NTAPI * pNtQueryInformationProcess)
     (HANDLE, UINT, PVOID, ULONG, PULONG);
 
-    DWORD_PTR DebugHandle = 0;
-    int Status;
-    ULONG ReturnSize = 0;
+    const NTSTATUS StatusInfoLengthMismatch = (NTSTATUS)0xC0000004L;
+    const NTSTATUS StatusAccessViolation = (NTSTATUS)0xC0000005L;
+    const NTSTATUS StatusAccessDenied = (NTSTATUS)0xC0000022L;
+    const NTSTATUS StatusPortNotSet = (NTSTATUS)0xC0000353L;
+    const NTSTATUS StatusDatatypeMisalignment = (NTSTATUS)0x80000002L;
+    const ULONG SentinelReturnLength = 0xB6B6B6B6;
+#ifdef _WIN64
+    const ULONG UnwrittenReturnLength = SentinelReturnLength;
+#else
+    // The WOW64 thunk leaves this value when the native call does not write
+    // ReturnLength.
+    const ULONG UnwrittenReturnLength = (ULONG)-(LONG)sizeof(ULONG);
+#endif
+    const ULONG_PTR SentinelHandle = (ULONG_PTR)-1;
 
-    // Get NtQueryInformationProcess
     pNtQueryInformationProcess NtQIP = (pNtQueryInformationProcess)
                                        GetProcAddress(GetModuleHandle(TEXT("ntdll.dll")),
                                                "NtQueryInformationProcess");
-
-    Status = NtQIP(GetCurrentProcess(),
-                   30, // ProcessDebugHandle
-                   &DebugHandle, sizeof(DebugHandle), &ReturnSize);
-
-    if(Status != 0x00000000)
-    {
-        if(Status != 0xC0000353)  //STATUS_PORT_NOT_SET
-            printf("NtQueryInformationProcess failed with %X, %u\n", Status, ReturnSize);
+    if(NtQIP == nullptr)
         return false;
+
+    bool Detected = false;
+    ULONG_PTR DebugHandle = SentinelHandle;
+    ULONG ReturnSize = SentinelReturnLength;
+
+    // Length validation happens before all handle and buffer validation. It does
+    // not write either output, including ReturnLength.
+    const ULONG InvalidLengths[] = { sizeof(DebugHandle) - 1, sizeof(DebugHandle) + 1 };
+    for(ULONG Length : InvalidLengths)
+    {
+        DebugHandle = SentinelHandle;
+        ReturnSize = SentinelReturnLength;
+        NTSTATUS Status = NtQIP(GetCurrentProcess(),
+                                30, // ProcessDebugObjectHandle
+                                &DebugHandle,
+                                Length,
+                                &ReturnSize);
+        if(Status != StatusInfoLengthMismatch ||
+                DebugHandle != SentinelHandle ||
+                ReturnSize != UnwrittenReturnLength)
+        {
+            printf("ProcessDebugObjectHandle length contract mismatch: %08X, %p, %08X, %u\n",
+                   Status, (PVOID)DebugHandle, ReturnSize, Length);
+            Detected = true;
+        }
     }
 
-
-    if(DebugHandle)
+    // A null output with the exact length is probed after process-handle access.
+    ReturnSize = SentinelReturnLength;
+    NTSTATUS Status = NtQIP(GetCurrentProcess(),
+                            30,
+                            nullptr,
+                            sizeof(DebugHandle),
+                            &ReturnSize);
+    if(Status != StatusAccessViolation || ReturnSize != UnwrittenReturnLength)
     {
-        CloseHandle((HANDLE)DebugHandle);
+        printf("ProcessDebugObjectHandle null-buffer contract mismatch: %08X, %08X\n", Status, ReturnSize);
+        Detected = true;
+    }
+
+#ifdef _WIN64
+    __declspec(align(8)) unsigned char Output[sizeof(HANDLE) + 8];
+    HANDLE LimitedProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION,
+                                        FALSE,
+                                        GetCurrentProcessId());
+    if(LimitedProcess != nullptr)
+    {
+        memset(Output, 0xA5, sizeof(Output));
+        ReturnSize = SentinelReturnLength;
+        Status = NtQIP(LimitedProcess,
+                       30,
+                       Output + 1,
+                       sizeof(HANDLE),
+                       &ReturnSize);
+        if(Status != StatusDatatypeMisalignment || ReturnSize != SentinelReturnLength)
+        {
+            printf("ProcessDebugObjectHandle validation-order mismatch: %08X\n", Status);
+            Detected = true;
+        }
+
+        memset(Output, 0xA5, sizeof(Output));
+        ReturnSize = SentinelReturnLength;
+        Status = NtQIP(LimitedProcess,
+                       30,
+                       Output,
+                       sizeof(HANDLE),
+                       &ReturnSize);
+        if(Status != StatusAccessDenied || ReturnSize != SentinelReturnLength)
+        {
+            printf("ProcessDebugObjectHandle access contract mismatch: %08X\n", Status);
+            Detected = true;
+        }
+        CloseHandle(LimitedProcess);
+    }
+
+    // Native x64 requires four-byte rather than pointer-size alignment.
+    memset(Output, 0xA5, sizeof(Output));
+    ReturnSize = SentinelReturnLength;
+    Status = NtQIP(GetCurrentProcess(),
+                   30,
+                   Output + 4,
+                   sizeof(HANDLE),
+                   &ReturnSize);
+    ULONG_PTR UnalignedHandle = SentinelHandle;
+    memcpy(&UnalignedHandle, Output + 4, sizeof(UnalignedHandle));
+    if(Status == STATUS_SUCCESS && UnalignedHandle != 0 && UnalignedHandle != SentinelHandle)
+        CloseHandle((HANDLE)UnalignedHandle);
+    if(Status != StatusPortNotSet || UnalignedHandle != 0 || ReturnSize != sizeof(HANDLE))
+    {
+        printf("ProcessDebugObjectHandle alignment contract mismatch: %08X\n", Status);
+        Detected = true;
+    }
+#endif
+
+    DebugHandle = SentinelHandle;
+    ReturnSize = SentinelReturnLength;
+    Status = NtQIP(GetCurrentProcess(),
+                   30,
+                   &DebugHandle,
+                   sizeof(DebugHandle),
+                   &ReturnSize);
+    if(Status == STATUS_SUCCESS)
+    {
+        if(DebugHandle != 0 && DebugHandle != SentinelHandle)
+            CloseHandle((HANDLE)DebugHandle);
         return true;
     }
+    if(Status != StatusPortNotSet || ReturnSize != sizeof(HANDLE)
+#ifdef _WIN64
+            || DebugHandle != 0
+#endif
+      )
+    {
+        printf("ProcessDebugObjectHandle result contract mismatch: %08X, %u\n", Status, ReturnSize);
+        Detected = true;
+    }
 
-    else
-        return false;
+    // The output is written before ReturnLength. This order is observable when
+    // both pointers overlap.
+    DebugHandle = SentinelHandle;
+    Status = NtQIP(GetCurrentProcess(),
+                   30,
+                   &DebugHandle,
+                   sizeof(DebugHandle),
+                   (PULONG)&DebugHandle);
+    if(Status != StatusPortNotSet || DebugHandle != sizeof(HANDLE))
+    {
+        printf("ProcessDebugObjectHandle overlap contract mismatch: %08X\n", Status);
+        Detected = true;
+    }
+
+    return Detected;
 }
 
 bool HideFromDebugger()
@@ -482,6 +605,9 @@ bool CheckNtClose()
 
 int main(int argc, char* argv[])
 {
+    if(argc == 2 && strcmp(argv[1], "--process-debug-object-contract") == 0)
+        return CheckProcessDebugObjectHandle() ? 1 : 0;
+
     char title[256] = "";
     sprintf_s(title, "pid: %d", (int)GetCurrentProcessId());
     SetConsoleTitleA(title);

--- a/TitanHideTest/main.cpp
+++ b/TitanHideTest/main.cpp
@@ -304,6 +304,16 @@ bool CheckThreadHideFromDebuggerContract()
     }
 
     TerminateThread(Thread, 0);
+    WaitForSingleObject(Thread, INFINITE);
+    Hidden = FALSE;
+    ReturnLength = 0;
+    Status = NtQIT(Thread, 0x11, &Hidden, sizeof(Hidden), &ReturnLength);
+    if(!NT_SUCCESS(Status) || Hidden != TRUE || ReturnLength != sizeof(Hidden))
+    {
+        printf("Exited ThreadHideFromDebugger state mismatch: %08X, %u, %u\n",
+               Status, Hidden, ReturnLength);
+        Detected = true;
+    }
     CloseHandle(Thread);
 
     // A thread created with the hide flag has the same observable state as one


### PR DESCRIPTION
## Summary

Match native anti-debug syscall behavior so malformed calls, thread lifecycle transitions, and overlapping output pointers cannot distinguish TitanHide's emulation from native state, without ever applying a delayed one-way thread-hide request.

## Confirmed side channels

Live testing and hook-path auditing identified these observable differences:

1. `ProcessDebugObjectHandle` checked process access before output alignment. A restricted process handle plus a misaligned output returned `STATUS_ACCESS_DENIED`; native Windows returns `STATUS_DATATYPE_MISALIGNMENT`.
2. `ThreadHideFromDebugger` queries always returned `TRUE`, including for fresh threads that never requested hiding.
3. Existing hidden threads and threads created with `THREAD_CREATE_FLAGS_HIDE_FROM_DEBUGGER` lost their observable hide state after TitanHide physically stripped the bit.
4. Failed `NtGetContextThread` calls still zeroed debug-register fields; native Windows leaves failed output untouched.
5. `ObjectTypesInformation` traversal trusted overwriteable `UNICODE_STRING` fields. Legal `ReturnLength` overlap could fault or skip DebugObject count filtering.
6. Internal kernel-mode `Zw*` calls could enter user-mode filtering paths and expose different statuses or corrupt kernel buffers.
7. Concurrent hide/unhide updates could race and corrupt virtual hide state.

## Changes

- Reproduce `ProcessDebugObjectHandle` length, four-byte alignment, access, probing, output, and overlap order.
- Track successful virtual `ThreadHideFromDebugger` state by referenced thread object.
- Seed state when stripping preexisting flags and after successful hide-on-create calls.
- Retain exited-thread state until unhide/unload so queries through surviving handles remain native-compatible.
- Never restore or fall back to the physical one-way flag for intercepted set/create requests; table exhaustion remains fail-closed and preferentially evicts exited entries.
- Roll back a DKOM clear immediately only when a preexisting physical flag cannot be virtualized.
- Preserve context output when native `NtGetContextThread` fails, including WOW64.
- Parse `ObjectTypesInformation` through bounded inline layout and a cached fixed DebugObject type signature, independent of any single field overwritten by `ReturnLength`, and stop at the native returned-byte/count bounds.
- Preserve the reference-free active DebugObject accounting added in `35eaa4a`.
- Bypass filtering for kernel-mode callers.
- Serialize hide table reads and updates.
- Add x86/WOW64 and x64 live-system contract tests for all user-visible contracts.

## Verification

The native contract suite covers unattached and actively debugged processes, restricted process/thread handles, malformed lengths, null and misaligned outputs, fresh/set/create/exited hidden threads, failed context queries, and overlaps with pointers, lengths, inline names, and type indexes, plus an oversized-buffer tail sentinel.

Runtime validation with TitanHide enabled still requires dedicated Windows 7/10/11 VMs with PatchGuard and DSE disabled.
